### PR TITLE
add explicit nuget dep to System.Memory 4.5.5

### DIFF
--- a/NuGet/IronSoftware.Drawing.nuspec
+++ b/NuGet/IronSoftware.Drawing.nuspec
@@ -49,6 +49,7 @@ All new classes developed to support conversion between: (System.Drawing, SixLab
 		<repository type="git" url="https://github.com/iron-software/IronSoftware.Drawing.Common" commit="$commit$" />
 		<dependencies>
 			<group targetFramework="net462">
+				<dependency id="System.Memory" version="4.5.5" />
 				<dependency id="SixLabors.ImageSharp" version="2.1.3" />
 				<dependency id="BitMiracle.LibTiff.NET" version="2.4.649" />
 			</group>


### PR DESCRIPTION
add explicit nuget dep to System.Memory 4.5.5

works when I add this nuget package so hopefully this should be enough