### PR TITLE
adds nuget dependency to System.Memory v4.5.5 for net462

### DIFF
--- a/NuGet/IronSoftware.Drawing.nuspec
+++ b/NuGet/IronSoftware.Drawing.nuspec
@@ -58,6 +58,7 @@ Bug Fixed
 		<repository type="git" url="https://github.com/iron-software/IronSoftware.Drawing.Common" commit="$commit$" />
 		<dependencies>
 			<group targetFramework="net462">
+				<dependency id="System.Memory" version="4.5.5" />
 				<dependency id="SixLabors.ImageSharp" version="2.1.3" />
 				<dependency id="BitMiracle.LibTiff.NET" version="2.4.649" />
 			</group>


### PR DESCRIPTION
adds nuget dependency to System.Memory v4.5.5 for net462

this fixes the issue when I do this locally, should hopefully work