### PR TITLE
Iron 867 fixing framework

### DIFF
--- a/IronSoftware.Drawing/IronSoftware.Drawing.Common.Tests/IronSoftware.Drawing.Common.Tests.csproj
+++ b/IronSoftware.Drawing/IronSoftware.Drawing.Common.Tests/IronSoftware.Drawing.Common.Tests.csproj
@@ -24,9 +24,6 @@
 	<PackageReference Include="Microsoft.Maui.Graphics">
       <Version>7.0.49</Version>
     </PackageReference>
-    <PackageReference Include="SixLabors.ImageSharp">
-      <Version>2.1.3</Version>
-    </PackageReference>
     <PackageReference Include="SkiaSharp">
       <Version>2.88.3</Version>
     </PackageReference>

--- a/IronSoftware.Drawing/IronSoftware.Drawing.Common/IronSoftware.Drawing.Common.csproj
+++ b/IronSoftware.Drawing/IronSoftware.Drawing.Common/IronSoftware.Drawing.Common.csproj
@@ -23,7 +23,6 @@
 	<ItemGroup>
 		<PackageReference Include="BitMiracle.LibTiff.NET" Version="2.4.649" />
 		<PackageReference Include="Microsoft.Maui.Graphics" Version="7.0.49" />
-		<PackageReference Include="SixLabors.ImageSharp" Version="2.1.3" />
 		<PackageReference Include="SixLabors.ImageSharp.Drawing" Version="1.0.0-beta15" />
 		<PackageReference Include="SkiaSharp" Version="2.88.3" />
 		<PackageReference Include="SkiaSharp.NativeAssets.Linux" Version="2.88.3" />

--- a/NuGet/IronSoftware.Drawing.nuspec
+++ b/NuGet/IronSoftware.Drawing.nuspec
@@ -48,7 +48,7 @@ For general support and technical inquiries, please email us at: developers@iron
 		<dependencies>
 			<group targetFramework="net462">
 				<dependency id="System.Memory" version="4.5.5" />
-				<dependency id="SixLabors.ImageSharp" version="2.1.3" />
+				<dependency id="SixLabors.ImageSharp.Drawing" version="1.0.0-beta15" />
 				<dependency id="BitMiracle.LibTiff.NET" version="2.4.649" />
 			</group>
 			<group targetFramework="netstandard20">

--- a/NuGet/IronSoftware.Drawing.nuspec
+++ b/NuGet/IronSoftware.Drawing.nuspec
@@ -46,13 +46,8 @@ For general support and technical inquiries, please email us at: developers@iron
 		<tags>Images, Bitmap, SkiaSharp, SixLabors, BitMiracle, Maui, SVG, TIFF, TIF, GIF, JPEG, PNG, Color, Rectangle, Drawing, C#, VB.NET, ASPX, create, render, generate, standard, netstandard2.0, core, netcore</tags>
 		<repository type="git" url="https://github.com/iron-software/IronSoftware.Drawing.Common" commit="$commit$" />
 		<dependencies>
-			<group targetFramework="net462">
-				<dependency id="System.Memory" version="4.5.5" />
-				<dependency id="SixLabors.ImageSharp.Drawing" version="1.0.0-beta15" />
-				<dependency id="BitMiracle.LibTiff.NET" version="2.4.649" />
-			</group>
-			<group targetFramework="netstandard20">
-				<dependency id="SixLabors.ImageSharp.Drawing" version="1.0.0-beta15" />
+			<group>
+				<dependency id="SixLabors.ImageSharp" version="2.1.3" />
 				<dependency id="BitMiracle.LibTiff.NET" version="2.4.649" />
 			</group>
 		</dependencies>
@@ -63,5 +58,7 @@ For general support and technical inquiries, please email us at: developers@iron
 		<file src=".\README.txt" target=".\" />
 		<file src=".\README.md" target="docs\" />
 		<file src="..\bin\$configuration$\netstandard2.0\IronSoftware.Drawing.Common.*" target="lib\netstandard2.0" />
+		<file src="..\bin\$configuration$\netstandard2.0\SixLabors.ImageSharp.Drawing.*" target="lib\netstandard2.0" />
+		<file src="..\bin\$configuration$\netstandard2.0\SixLabors.Fonts.*" target="lib\netstandard2.0" />
 	</files>
 </package>

--- a/NuGet/IronSoftware.Drawing.nuspec
+++ b/NuGet/IronSoftware.Drawing.nuspec
@@ -42,7 +42,7 @@ For general support and technical inquiries, please email us at: developers@iron
   - Fixes a bug when saving an image without specifying ImageFormat
 * Color
   - [Hotfix] Fixes a bug when comparing Color with null</releaseNotes>
-		<copyright>Copyright © Iron Software 2022</copyright>
+		<copyright>Copyright © Iron Software 2022-2023</copyright>
 		<tags>Images, Bitmap, SkiaSharp, SixLabors, BitMiracle, Maui, SVG, TIFF, TIF, GIF, JPEG, PNG, Color, Rectangle, Drawing, C#, VB.NET, ASPX, create, render, generate, standard, netstandard2.0, core, netcore</tags>
 		<repository type="git" url="https://github.com/iron-software/IronSoftware.Drawing.Common" commit="$commit$" />
 		<dependencies>


### PR DESCRIPTION
- Including `SixLabors.ImageSharp.Drawing` and `SixLabors.Fonts` into lib folder
- Update copyright
