### PR TITLE
Restrict ImageSharp dependency to version 2.x

### DIFF
--- a/NuGet/IronSoftware.Drawing.nuspec
+++ b/NuGet/IronSoftware.Drawing.nuspec
@@ -43,7 +43,7 @@ For general support and technical inquiries, please email us at: developers@iron
 		<repository type="git" url="https://github.com/iron-software/IronSoftware.Drawing.Common" commit="$commit$" />
 		<dependencies>
 			<group>
-				<dependency id="SixLabors.ImageSharp" version="[,2.1.3)" />
+				<dependency id="SixLabors.ImageSharp" version="[,3.0.0)" />
 				<dependency id="BitMiracle.LibTiff.NET" version="2.4.649" />
 			</group>
 		</dependencies>


### PR DESCRIPTION
### Description:
This PR modifies the dependency constraints for the SixLabors.ImageSharp library in the nuspec file. By setting the maximum version to 3.0.0, we ensure that only version 2.x of the library can be installed. This restriction is necessary due to potential compatibility issues or breaking changes introduced in version 3.x.

### Changes:
- Update the nuspec file to set the maximum allowed version of ImageSharp to 3.0.0.

### Tested:
1. Install SixLabors.ImageSharp v3.0.0
2. Install IronSoftware.System.Drawing v1.0.13130-ci
3. It should throw an error with SixLabors.ImageSharp (< 3.0.0)
4. It will be the same if install IronSoftware.System.Drawing v1.0.13130-ci then try to upgrade SixLabors.ImageSharp to v3.0.0
