### PR TITLE
Prepare for old SixLabors version release

### DIFF
--- a/IronSoftware.Drawing/IronSoftware.Drawing.Common/AnyBitmap.cs
+++ b/IronSoftware.Drawing/IronSoftware.Drawing.Common/AnyBitmap.cs
@@ -42,7 +42,7 @@ namespace IronSoftware.Drawing
                 }
                 catch (Exception e) when (e is MissingMethodException || e is TypeInitializationException)
                 {
-                    throw new NotSupportedException("Due to conflicts between SixLabors v2 and v3 you must upgrade to a version of IronSoftware.System.Drawing which supports SixLabors.ImageSharp v3.", e);
+                    throw new NotSupportedException("Due to conflicts between SixLabors.ImageSharp v2 and v3, to use SixLabors.ImageSharp v3 with Iron Software products please install IronSoftware.System.Drawing v.2023.4.1-prerelease NuGet package which supports SixLabors.ImageSharp v3.", e);
                 }
             }
         }
@@ -60,7 +60,7 @@ namespace IronSoftware.Drawing
                 }
                 catch (Exception e) when (e is MissingMethodException || e is TypeInitializationException)
                 {
-                    throw new NotSupportedException("Due to conflicts between SixLabors v2 and v3 you must upgrade to a version of IronSoftware.System.Drawing which supports SixLabors.ImageSharp v3.", e);
+                    throw new NotSupportedException("Due to conflicts between SixLabors.ImageSharp v2 and v3, to use SixLabors.ImageSharp v3 with Iron Software products please install IronSoftware.System.Drawing v.2023.4.1-prerelease NuGet package which supports SixLabors.ImageSharp v3.", e);
                 }
             }
         }
@@ -128,7 +128,7 @@ namespace IronSoftware.Drawing
             }
             catch (Exception e) when (e is MissingMethodException || e is TypeInitializationException)
             {
-                throw new NotSupportedException("Due to conflicts between SixLabors v2 and v3 you must upgrade to a version of IronSoftware.System.Drawing which supports SixLabors.ImageSharp v3.", e);
+                throw new NotSupportedException("Due to conflicts between SixLabors.ImageSharp v2 and v3, to use SixLabors.ImageSharp v3 with Iron Software products please install IronSoftware.System.Drawing v.2023.4.1-prerelease NuGet package which supports SixLabors.ImageSharp v3.", e);
             }
         }
 
@@ -153,7 +153,7 @@ namespace IronSoftware.Drawing
             }
             catch (Exception e) when (e is MissingMethodException || e is TypeInitializationException)
             {
-                throw new NotSupportedException("Due to conflicts between SixLabors v2 and v3 you must upgrade to a version of IronSoftware.System.Drawing which supports SixLabors.ImageSharp v3.", e);
+                throw new NotSupportedException("Due to conflicts between SixLabors.ImageSharp v2 and v3, to use SixLabors.ImageSharp v3 with Iron Software products please install IronSoftware.System.Drawing v.2023.4.1-prerelease NuGet package which supports SixLabors.ImageSharp v3.", e);
             }
         }
 
@@ -176,7 +176,7 @@ namespace IronSoftware.Drawing
             }
             catch (Exception e) when (e is MissingMethodException || e is TypeInitializationException)
             {
-                throw new NotSupportedException("Due to conflicts between SixLabors v2 and v3 you must upgrade to a version of IronSoftware.System.Drawing which supports SixLabors.ImageSharp v3.", e);
+                throw new NotSupportedException("Due to conflicts between SixLabors.ImageSharp v2 and v3, to use SixLabors.ImageSharp v3 with Iron Software products please install IronSoftware.System.Drawing v.2023.4.1-prerelease NuGet package which supports SixLabors.ImageSharp v3.", e);
             }
         }
 
@@ -202,7 +202,7 @@ namespace IronSoftware.Drawing
             }
             catch (Exception e) when (e is MissingMethodException || e is TypeInitializationException)
             {
-                throw new NotSupportedException("Due to conflicts between SixLabors v2 and v3 you must upgrade to a version of IronSoftware.System.Drawing which supports SixLabors.ImageSharp v3.", e);
+                throw new NotSupportedException("Due to conflicts between SixLabors.ImageSharp v2 and v3, to use SixLabors.ImageSharp v3 with Iron Software products please install IronSoftware.System.Drawing v.2023.4.1-prerelease NuGet package which supports SixLabors.ImageSharp v3.", e);
             }
         }
 
@@ -224,7 +224,7 @@ namespace IronSoftware.Drawing
             }
             catch (Exception e) when (e is MissingMethodException || e is TypeInitializationException)
             {
-                throw new NotSupportedException("Due to conflicts between SixLabors v2 and v3 you must upgrade to a version of IronSoftware.System.Drawing which supports SixLabors.ImageSharp v3.", e);
+                throw new NotSupportedException("Due to conflicts between SixLabors.ImageSharp v2 and v3, to use SixLabors.ImageSharp v3 with Iron Software products please install IronSoftware.System.Drawing v.2023.4.1-prerelease NuGet package which supports SixLabors.ImageSharp v3.", e);
             }
         }
 
@@ -246,7 +246,7 @@ namespace IronSoftware.Drawing
             }
             catch (Exception e) when (e is MissingMethodException || e is TypeInitializationException)
             {
-                throw new NotSupportedException("Due to conflicts between SixLabors v2 and v3 you must upgrade to a version of IronSoftware.System.Drawing which supports SixLabors.ImageSharp v3.", e);
+                throw new NotSupportedException("Due to conflicts between SixLabors.ImageSharp v2 and v3, to use SixLabors.ImageSharp v3 with Iron Software products please install IronSoftware.System.Drawing v.2023.4.1-prerelease NuGet package which supports SixLabors.ImageSharp v3.", e);
             }
         }
 
@@ -303,7 +303,7 @@ namespace IronSoftware.Drawing
             }
             catch (Exception e) when (e is MissingMethodException || e is TypeInitializationException)
             {
-                throw new NotSupportedException("Due to conflicts between SixLabors v2 and v3 you must upgrade to a version of IronSoftware.System.Drawing which supports SixLabors.ImageSharp v3.", e);
+                throw new NotSupportedException("Due to conflicts between SixLabors.ImageSharp v2 and v3, to use SixLabors.ImageSharp v3 with Iron Software products please install IronSoftware.System.Drawing v.2023.4.1-prerelease NuGet package which supports SixLabors.ImageSharp v3.", e);
             }
         }
 
@@ -351,7 +351,7 @@ namespace IronSoftware.Drawing
             }
             catch (Exception e) when (e is MissingMethodException || e is TypeInitializationException)
             {
-                throw new NotSupportedException("Due to conflicts between SixLabors v2 and v3 you must upgrade to a version of IronSoftware.System.Drawing which supports SixLabors.ImageSharp v3.", e);
+                throw new NotSupportedException("Due to conflicts between SixLabors.ImageSharp v2 and v3, to use SixLabors.ImageSharp v3 with Iron Software products please install IronSoftware.System.Drawing v.2023.4.1-prerelease NuGet package which supports SixLabors.ImageSharp v3.", e);
             }
             catch
             {
@@ -375,7 +375,7 @@ namespace IronSoftware.Drawing
             }
             catch (Exception e) when (e is MissingMethodException || e is TypeInitializationException)
             {
-                throw new NotSupportedException("Due to conflicts between SixLabors v2 and v3 you must upgrade to a version of IronSoftware.System.Drawing which supports SixLabors.ImageSharp v3.", e);
+                throw new NotSupportedException("Due to conflicts between SixLabors.ImageSharp v2 and v3, to use SixLabors.ImageSharp v3 with Iron Software products please install IronSoftware.System.Drawing v.2023.4.1-prerelease NuGet package which supports SixLabors.ImageSharp v3.", e);
             }
             catch
             {
@@ -437,7 +437,7 @@ namespace IronSoftware.Drawing
             }
             catch (Exception e) when (e is MissingMethodException || e is TypeInitializationException)
             {
-                throw new NotSupportedException("Due to conflicts between SixLabors v2 and v3 you must upgrade to a version of IronSoftware.System.Drawing which supports SixLabors.ImageSharp v3.", e);
+                throw new NotSupportedException("Due to conflicts between SixLabors.ImageSharp v2 and v3, to use SixLabors.ImageSharp v3 with Iron Software products please install IronSoftware.System.Drawing v.2023.4.1-prerelease NuGet package which supports SixLabors.ImageSharp v3.", e);
             }
         }
         /// <summary>
@@ -455,7 +455,7 @@ namespace IronSoftware.Drawing
             }
             catch (Exception e) when (e is MissingMethodException || e is TypeInitializationException)
             {
-                throw new NotSupportedException("Due to conflicts between SixLabors v2 and v3 you must upgrade to a version of IronSoftware.System.Drawing which supports SixLabors.ImageSharp v3.", e);
+                throw new NotSupportedException("Due to conflicts between SixLabors.ImageSharp v2 and v3, to use SixLabors.ImageSharp v3 with Iron Software products please install IronSoftware.System.Drawing v.2023.4.1-prerelease NuGet package which supports SixLabors.ImageSharp v3.", e);
             }
         }
 
@@ -495,7 +495,7 @@ namespace IronSoftware.Drawing
             }
             catch (Exception e) when (e is MissingMethodException || e is TypeInitializationException)
             {
-                throw new NotSupportedException("Due to conflicts between SixLabors v2 and v3 you must upgrade to a version of IronSoftware.System.Drawing which supports SixLabors.ImageSharp v3.", e);
+                throw new NotSupportedException("Due to conflicts between SixLabors.ImageSharp v2 and v3, to use SixLabors.ImageSharp v3 with Iron Software products please install IronSoftware.System.Drawing v.2023.4.1-prerelease NuGet package which supports SixLabors.ImageSharp v3.", e);
             }
         }
 
@@ -513,7 +513,7 @@ namespace IronSoftware.Drawing
             }
             catch (Exception e) when (e is MissingMethodException || e is TypeInitializationException)
             {
-                throw new NotSupportedException("Due to conflicts between SixLabors v2 and v3 you must upgrade to a version of IronSoftware.System.Drawing which supports SixLabors.ImageSharp v3.", e);
+                throw new NotSupportedException("Due to conflicts between SixLabors.ImageSharp v2 and v3, to use SixLabors.ImageSharp v3 with Iron Software products please install IronSoftware.System.Drawing v.2023.4.1-prerelease NuGet package which supports SixLabors.ImageSharp v3.", e);
             }
         }
 
@@ -531,7 +531,7 @@ namespace IronSoftware.Drawing
             }
             catch (Exception e) when (e is MissingMethodException || e is TypeInitializationException)
             {
-                throw new NotSupportedException("Due to conflicts between SixLabors v2 and v3 you must upgrade to a version of IronSoftware.System.Drawing which supports SixLabors.ImageSharp v3.", e);
+                throw new NotSupportedException("Due to conflicts between SixLabors.ImageSharp v2 and v3, to use SixLabors.ImageSharp v3 with Iron Software products please install IronSoftware.System.Drawing v.2023.4.1-prerelease NuGet package which supports SixLabors.ImageSharp v3.", e);
             }
         }
 
@@ -567,7 +567,7 @@ namespace IronSoftware.Drawing
             }
             catch (Exception e) when (e is MissingMethodException || e is TypeInitializationException)
             {
-                throw new NotSupportedException("Due to conflicts between SixLabors v2 and v3 you must upgrade to a version of IronSoftware.System.Drawing which supports SixLabors.ImageSharp v3.", e);
+                throw new NotSupportedException("Due to conflicts between SixLabors.ImageSharp v2 and v3, to use SixLabors.ImageSharp v3 with Iron Software products please install IronSoftware.System.Drawing v.2023.4.1-prerelease NuGet package which supports SixLabors.ImageSharp v3.", e);
             }
         }
 
@@ -648,7 +648,7 @@ namespace IronSoftware.Drawing
                 }
                 catch (Exception e) when (e is MissingMethodException || e is TypeInitializationException)
                 {
-                    throw new NotSupportedException("Due to conflicts between SixLabors v2 and v3 you must upgrade to a version of IronSoftware.System.Drawing which supports SixLabors.ImageSharp v3.", e);
+                    throw new NotSupportedException("Due to conflicts between SixLabors.ImageSharp v2 and v3, to use SixLabors.ImageSharp v3 with Iron Software products please install IronSoftware.System.Drawing v.2023.4.1-prerelease NuGet package which supports SixLabors.ImageSharp v3.", e);
                 }
             }
         }
@@ -668,7 +668,7 @@ namespace IronSoftware.Drawing
                 }
                 catch (Exception e) when (e is MissingMethodException || e is TypeInitializationException)
                 {
-                    throw new NotSupportedException("Due to conflicts between SixLabors v2 and v3 you must upgrade to a version of IronSoftware.System.Drawing which supports SixLabors.ImageSharp v3.", e);
+                    throw new NotSupportedException("Due to conflicts between SixLabors.ImageSharp v2 and v3, to use SixLabors.ImageSharp v3 with Iron Software products please install IronSoftware.System.Drawing v.2023.4.1-prerelease NuGet package which supports SixLabors.ImageSharp v3.", e);
                 }
             }
         }
@@ -696,7 +696,7 @@ namespace IronSoftware.Drawing
                     }
                     catch (Exception e) when (e is MissingMethodException || e is TypeInitializationException)
                     {
-                        throw new NotSupportedException("Due to conflicts between SixLabors v2 and v3 you must upgrade to a version of IronSoftware.System.Drawing which supports SixLabors.ImageSharp v3.", e);
+                        throw new NotSupportedException("Due to conflicts between SixLabors.ImageSharp v2 and v3, to use SixLabors.ImageSharp v3 with Iron Software products please install IronSoftware.System.Drawing v.2023.4.1-prerelease NuGet package which supports SixLabors.ImageSharp v3.", e);
                     }
 
                     return images;
@@ -726,7 +726,7 @@ namespace IronSoftware.Drawing
             }
             catch (Exception e) when (e is MissingMethodException || e is TypeInitializationException)
             {
-                throw new NotSupportedException("Due to conflicts between SixLabors v2 and v3 you must upgrade to a version of IronSoftware.System.Drawing which supports SixLabors.ImageSharp v3.", e);
+                throw new NotSupportedException("Due to conflicts between SixLabors.ImageSharp v2 and v3, to use SixLabors.ImageSharp v3 with Iron Software products please install IronSoftware.System.Drawing v.2023.4.1-prerelease NuGet package which supports SixLabors.ImageSharp v3.", e);
             }
         }
 
@@ -748,7 +748,7 @@ namespace IronSoftware.Drawing
             }
             catch (Exception e) when (e is MissingMethodException || e is TypeInitializationException)
             {
-                throw new NotSupportedException("Due to conflicts between SixLabors v2 and v3 you must upgrade to a version of IronSoftware.System.Drawing which supports SixLabors.ImageSharp v3.", e);
+                throw new NotSupportedException("Due to conflicts between SixLabors.ImageSharp v2 and v3, to use SixLabors.ImageSharp v3 with Iron Software products please install IronSoftware.System.Drawing v.2023.4.1-prerelease NuGet package which supports SixLabors.ImageSharp v3.", e);
             }
         }
 
@@ -770,7 +770,7 @@ namespace IronSoftware.Drawing
             }
             catch (Exception e) when (e is MissingMethodException || e is TypeInitializationException)
             {
-                throw new NotSupportedException("Due to conflicts between SixLabors v2 and v3 you must upgrade to a version of IronSoftware.System.Drawing which supports SixLabors.ImageSharp v3.", e);
+                throw new NotSupportedException("Due to conflicts between SixLabors.ImageSharp v2 and v3, to use SixLabors.ImageSharp v3 with Iron Software products please install IronSoftware.System.Drawing v.2023.4.1-prerelease NuGet package which supports SixLabors.ImageSharp v3.", e);
             }
         }
 
@@ -792,7 +792,7 @@ namespace IronSoftware.Drawing
             }
             catch (Exception e) when (e is MissingMethodException || e is TypeInitializationException)
             {
-                throw new NotSupportedException("Due to conflicts between SixLabors v2 and v3 you must upgrade to a version of IronSoftware.System.Drawing which supports SixLabors.ImageSharp v3.", e);
+                throw new NotSupportedException("Due to conflicts between SixLabors.ImageSharp v2 and v3, to use SixLabors.ImageSharp v3 with Iron Software products please install IronSoftware.System.Drawing v.2023.4.1-prerelease NuGet package which supports SixLabors.ImageSharp v3.", e);
             }
         }
         
@@ -810,7 +810,7 @@ namespace IronSoftware.Drawing
             }
             catch (Exception e) when (e is MissingMethodException || e is TypeInitializationException)
             {
-                throw new NotSupportedException("Due to conflicts between SixLabors v2 and v3 you must upgrade to a version of IronSoftware.System.Drawing which supports SixLabors.ImageSharp v3.", e);
+                throw new NotSupportedException("Due to conflicts between SixLabors.ImageSharp v2 and v3, to use SixLabors.ImageSharp v3 with Iron Software products please install IronSoftware.System.Drawing v.2023.4.1-prerelease NuGet package which supports SixLabors.ImageSharp v3.", e);
             }
         }
         
@@ -829,7 +829,7 @@ namespace IronSoftware.Drawing
             }
             catch (Exception e) when (e is MissingMethodException || e is TypeInitializationException)
             {
-                throw new NotSupportedException("Due to conflicts between SixLabors v2 and v3 you must upgrade to a version of IronSoftware.System.Drawing which supports SixLabors.ImageSharp v3.", e);
+                throw new NotSupportedException("Due to conflicts between SixLabors.ImageSharp v2 and v3, to use SixLabors.ImageSharp v3 with Iron Software products please install IronSoftware.System.Drawing v.2023.4.1-prerelease NuGet package which supports SixLabors.ImageSharp v3.", e);
             }
         }
 
@@ -875,7 +875,7 @@ namespace IronSoftware.Drawing
             }
             catch (Exception e) when (e is MissingMethodException || e is TypeInitializationException)
             {
-                throw new NotSupportedException("Due to conflicts between SixLabors v2 and v3 you must upgrade to a version of IronSoftware.System.Drawing which supports SixLabors.ImageSharp v3.", e);
+                throw new NotSupportedException("Due to conflicts between SixLabors.ImageSharp v2 and v3, to use SixLabors.ImageSharp v3 with Iron Software products please install IronSoftware.System.Drawing v.2023.4.1-prerelease NuGet package which supports SixLabors.ImageSharp v3.", e);
             }
         }
 
@@ -893,7 +893,7 @@ namespace IronSoftware.Drawing
             }
             catch (Exception e) when (e is MissingMethodException || e is TypeInitializationException)
             {
-                throw new NotSupportedException("Due to conflicts between SixLabors v2 and v3 you must upgrade to a version of IronSoftware.System.Drawing which supports SixLabors.ImageSharp v3.", e);
+                throw new NotSupportedException("Due to conflicts between SixLabors.ImageSharp v2 and v3, to use SixLabors.ImageSharp v3 with Iron Software products please install IronSoftware.System.Drawing v.2023.4.1-prerelease NuGet package which supports SixLabors.ImageSharp v3.", e);
             }
         }
 
@@ -923,7 +923,7 @@ namespace IronSoftware.Drawing
             }
             catch (Exception e) when (e is MissingMethodException || e is TypeInitializationException)
             {
-                throw new NotSupportedException("Due to conflicts between SixLabors v2 and v3 you must upgrade to a version of IronSoftware.System.Drawing which supports SixLabors.ImageSharp v3.", e);
+                throw new NotSupportedException("Due to conflicts between SixLabors.ImageSharp v2 and v3, to use SixLabors.ImageSharp v3 with Iron Software products please install IronSoftware.System.Drawing v.2023.4.1-prerelease NuGet package which supports SixLabors.ImageSharp v3.", e);
             }
         }
 
@@ -940,7 +940,7 @@ namespace IronSoftware.Drawing
                 }
                 catch (Exception e) when (e is MissingMethodException || e is TypeInitializationException)
                 {
-                    throw new NotSupportedException("Due to conflicts between SixLabors v2 and v3 you must upgrade to a version of IronSoftware.System.Drawing which supports SixLabors.ImageSharp v3.", e);
+                    throw new NotSupportedException("Due to conflicts between SixLabors.ImageSharp v2 and v3, to use SixLabors.ImageSharp v3 with Iron Software products please install IronSoftware.System.Drawing v.2023.4.1-prerelease NuGet package which supports SixLabors.ImageSharp v3.", e);
                 }
             }
         }
@@ -959,7 +959,7 @@ namespace IronSoftware.Drawing
                 }
                 catch (Exception e) when (e is MissingMethodException || e is TypeInitializationException)
                 {
-                    throw new NotSupportedException("Due to conflicts between SixLabors v2 and v3 you must upgrade to a version of IronSoftware.System.Drawing which supports SixLabors.ImageSharp v3.", e);
+                    throw new NotSupportedException("Due to conflicts between SixLabors.ImageSharp v2 and v3, to use SixLabors.ImageSharp v3 with Iron Software products please install IronSoftware.System.Drawing v.2023.4.1-prerelease NuGet package which supports SixLabors.ImageSharp v3.", e);
                 }
             }
         }
@@ -978,7 +978,7 @@ namespace IronSoftware.Drawing
                 }
                 catch (Exception e) when (e is MissingMethodException || e is TypeInitializationException)
                 {
-                    throw new NotSupportedException("Due to conflicts between SixLabors v2 and v3 you must upgrade to a version of IronSoftware.System.Drawing which supports SixLabors.ImageSharp v3.", e);
+                    throw new NotSupportedException("Due to conflicts between SixLabors.ImageSharp v2 and v3, to use SixLabors.ImageSharp v3 with Iron Software products please install IronSoftware.System.Drawing v.2023.4.1-prerelease NuGet package which supports SixLabors.ImageSharp v3.", e);
                 }
             }
         }
@@ -1004,7 +1004,7 @@ namespace IronSoftware.Drawing
             }
             catch (Exception e) when (e is MissingMethodException || e is TypeInitializationException)
             {
-                throw new NotSupportedException("Due to conflicts between SixLabors v2 and v3 you must upgrade to a version of IronSoftware.System.Drawing which supports SixLabors.ImageSharp v3.", e);
+                throw new NotSupportedException("Due to conflicts between SixLabors.ImageSharp v2 and v3, to use SixLabors.ImageSharp v3 with Iron Software products please install IronSoftware.System.Drawing v.2023.4.1-prerelease NuGet package which supports SixLabors.ImageSharp v3.", e);
             }
         }
 
@@ -1022,7 +1022,7 @@ namespace IronSoftware.Drawing
                 }
                 catch (Exception e) when (e is MissingMethodException || e is TypeInitializationException)
                 {
-                    throw new NotSupportedException("Due to conflicts between SixLabors v2 and v3 you must upgrade to a version of IronSoftware.System.Drawing which supports SixLabors.ImageSharp v3.", e);
+                    throw new NotSupportedException("Due to conflicts between SixLabors.ImageSharp v2 and v3, to use SixLabors.ImageSharp v3 with Iron Software products please install IronSoftware.System.Drawing v.2023.4.1-prerelease NuGet package which supports SixLabors.ImageSharp v3.", e);
                 }
             }
         }
@@ -1041,7 +1041,7 @@ namespace IronSoftware.Drawing
                 }
                 catch (Exception e) when (e is MissingMethodException || e is TypeInitializationException)
                 {
-                    throw new NotSupportedException("Due to conflicts between SixLabors v2 and v3 you must upgrade to a version of IronSoftware.System.Drawing which supports SixLabors.ImageSharp v3.", e);
+                    throw new NotSupportedException("Due to conflicts between SixLabors.ImageSharp v2 and v3, to use SixLabors.ImageSharp v3 with Iron Software products please install IronSoftware.System.Drawing v.2023.4.1-prerelease NuGet package which supports SixLabors.ImageSharp v3.", e);
                 }
             }
         }
@@ -1070,7 +1070,7 @@ namespace IronSoftware.Drawing
             }
             catch (Exception e) when (e is MissingMethodException || e is TypeInitializationException)
             {
-                throw new NotSupportedException("Due to conflicts between SixLabors v2 and v3 you must upgrade to a version of IronSoftware.System.Drawing which supports SixLabors.ImageSharp v3.", e);
+                throw new NotSupportedException("Due to conflicts between SixLabors.ImageSharp v2 and v3, to use SixLabors.ImageSharp v3 with Iron Software products please install IronSoftware.System.Drawing v.2023.4.1-prerelease NuGet package which supports SixLabors.ImageSharp v3.", e);
             }
         }
 
@@ -1097,7 +1097,7 @@ namespace IronSoftware.Drawing
             }
             catch (Exception e) when (e is MissingMethodException || e is TypeInitializationException)
             {
-                throw new NotSupportedException("Due to conflicts between SixLabors v2 and v3 you must upgrade to a version of IronSoftware.System.Drawing which supports SixLabors.ImageSharp v3.", e);
+                throw new NotSupportedException("Due to conflicts between SixLabors.ImageSharp v2 and v3, to use SixLabors.ImageSharp v3 with Iron Software products please install IronSoftware.System.Drawing v.2023.4.1-prerelease NuGet package which supports SixLabors.ImageSharp v3.", e);
             }
             catch (Exception e)
             {
@@ -1122,7 +1122,7 @@ namespace IronSoftware.Drawing
             }
             catch (Exception e) when (e is MissingMethodException || e is TypeInitializationException)
             {
-                throw new NotSupportedException("Due to conflicts between SixLabors v2 and v3 you must upgrade to a version of IronSoftware.System.Drawing which supports SixLabors.ImageSharp v3.", e);
+                throw new NotSupportedException("Due to conflicts between SixLabors.ImageSharp v2 and v3, to use SixLabors.ImageSharp v3 with Iron Software products please install IronSoftware.System.Drawing v.2023.4.1-prerelease NuGet package which supports SixLabors.ImageSharp v3.", e);
             }
             catch (Exception e)
             {
@@ -1153,7 +1153,7 @@ namespace IronSoftware.Drawing
             }
             catch (Exception e) when (e is MissingMethodException || e is TypeInitializationException)
             {
-                throw new NotSupportedException("Due to conflicts between SixLabors v2 and v3 you must upgrade to a version of IronSoftware.System.Drawing which supports SixLabors.ImageSharp v3.", e);
+                throw new NotSupportedException("Due to conflicts between SixLabors.ImageSharp v2 and v3, to use SixLabors.ImageSharp v3 with Iron Software products please install IronSoftware.System.Drawing v.2023.4.1-prerelease NuGet package which supports SixLabors.ImageSharp v3.", e);
             }
             catch (Exception e)
             {
@@ -1178,7 +1178,7 @@ namespace IronSoftware.Drawing
             }
             catch (Exception e) when (e is MissingMethodException || e is TypeInitializationException)
             {
-                throw new NotSupportedException("Due to conflicts between SixLabors v2 and v3 you must upgrade to a version of IronSoftware.System.Drawing which supports SixLabors.ImageSharp v3.", e);
+                throw new NotSupportedException("Due to conflicts between SixLabors.ImageSharp v2 and v3, to use SixLabors.ImageSharp v3 with Iron Software products please install IronSoftware.System.Drawing v.2023.4.1-prerelease NuGet package which supports SixLabors.ImageSharp v3.", e);
             }
             catch (Exception e)
             {
@@ -1209,7 +1209,7 @@ namespace IronSoftware.Drawing
             }
             catch (Exception e) when (e is MissingMethodException || e is TypeInitializationException)
             {
-                throw new NotSupportedException("Due to conflicts between SixLabors v2 and v3 you must upgrade to a version of IronSoftware.System.Drawing which supports SixLabors.ImageSharp v3.", e);
+                throw new NotSupportedException("Due to conflicts between SixLabors.ImageSharp v2 and v3, to use SixLabors.ImageSharp v3 with Iron Software products please install IronSoftware.System.Drawing v.2023.4.1-prerelease NuGet package which supports SixLabors.ImageSharp v3.", e);
             }
             catch (Exception e)
             {
@@ -1234,7 +1234,7 @@ namespace IronSoftware.Drawing
             }
             catch (Exception e) when (e is MissingMethodException || e is TypeInitializationException)
             {
-                throw new NotSupportedException("Due to conflicts between SixLabors v2 and v3 you must upgrade to a version of IronSoftware.System.Drawing which supports SixLabors.ImageSharp v3.", e);
+                throw new NotSupportedException("Due to conflicts between SixLabors.ImageSharp v2 and v3, to use SixLabors.ImageSharp v3 with Iron Software products please install IronSoftware.System.Drawing v.2023.4.1-prerelease NuGet package which supports SixLabors.ImageSharp v3.", e);
             }
             catch (Exception e)
             {
@@ -1808,7 +1808,7 @@ namespace IronSoftware.Drawing
             }
             catch (MissingMethodException e)
             {
-                throw new NotSupportedException("Due to conflicts between SixLabors v2 and v3 you must upgrade to a version of IronSoftware.System.Drawing which supports SixLabors.ImageSharp v3.", e);
+                throw new NotSupportedException("Due to conflicts between SixLabors.ImageSharp v2 and v3, to use SixLabors.ImageSharp v3 with Iron Software products please install IronSoftware.System.Drawing v.2023.4.1-prerelease NuGet package which supports SixLabors.ImageSharp v3.", e);
             }
             catch (Exception e)
             {
@@ -1842,7 +1842,7 @@ namespace IronSoftware.Drawing
             }
             catch (MissingMethodException e)
             {
-                throw new NotSupportedException("Due to conflicts between SixLabors v2 and v3 you must upgrade to a version of IronSoftware.System.Drawing which supports SixLabors.ImageSharp v3.", e);
+                throw new NotSupportedException("Due to conflicts between SixLabors.ImageSharp v2 and v3, to use SixLabors.ImageSharp v3 with Iron Software products please install IronSoftware.System.Drawing v.2023.4.1-prerelease NuGet package which supports SixLabors.ImageSharp v3.", e);
             }
             catch (Exception e)
             {
@@ -2294,7 +2294,7 @@ namespace IronSoftware.Drawing
             }
             catch (MissingMethodException e)
             {
-                throw new NotSupportedException("Due to conflicts between SixLabors v2 and v3 you must upgrade to a version of IronSoftware.System.Drawing which supports SixLabors.ImageSharp v3.", e);
+                throw new NotSupportedException("Due to conflicts between SixLabors.ImageSharp v2 and v3, to use SixLabors.ImageSharp v3 with Iron Software products please install IronSoftware.System.Drawing v.2023.4.1-prerelease NuGet package which supports SixLabors.ImageSharp v3.", e);
             }
             catch (Exception e)
             {

--- a/IronSoftware.Drawing/IronSoftware.Drawing.Common/AnyBitmap.cs
+++ b/IronSoftware.Drawing/IronSoftware.Drawing.Common/AnyBitmap.cs
@@ -24,6 +24,12 @@ namespace IronSoftware.Drawing
     /// </summary>
     public partial class AnyBitmap : IDisposable
     {
+        private const string IMAGE_SHARP_MISSING_METHOD_MESSAGE = 
+            "Due to conflicts between SixLabors.ImageSharp v2 and v3, " + 
+            "to use SixLabors.ImageSharp v3 with Iron Software products " + 
+            "please install IronSoftware.System.Drawing v.2023.4.1-prerelease " + 
+            "NuGet package which supports SixLabors.ImageSharp v3.";
+    
         private bool disposed = false;
         private SixLabors.ImageSharp.Image Image { get; set; }
         private byte[] Binary { get; set; }
@@ -42,7 +48,7 @@ namespace IronSoftware.Drawing
                 }
                 catch (Exception e) when (e is MissingMethodException || e is TypeInitializationException)
                 {
-                    throw new NotSupportedException("Due to conflicts between SixLabors.ImageSharp v2 and v3, to use SixLabors.ImageSharp v3 with Iron Software products please install IronSoftware.System.Drawing v.2023.4.1-prerelease NuGet package which supports SixLabors.ImageSharp v3.", e);
+                    throw new NotSupportedException(IMAGE_SHARP_MISSING_METHOD_MESSAGE, e);
                 }
             }
         }
@@ -60,7 +66,7 @@ namespace IronSoftware.Drawing
                 }
                 catch (Exception e) when (e is MissingMethodException || e is TypeInitializationException)
                 {
-                    throw new NotSupportedException("Due to conflicts between SixLabors.ImageSharp v2 and v3, to use SixLabors.ImageSharp v3 with Iron Software products please install IronSoftware.System.Drawing v.2023.4.1-prerelease NuGet package which supports SixLabors.ImageSharp v3.", e);
+                    throw new NotSupportedException(IMAGE_SHARP_MISSING_METHOD_MESSAGE, e);
                 }
             }
         }
@@ -128,7 +134,7 @@ namespace IronSoftware.Drawing
             }
             catch (Exception e) when (e is MissingMethodException || e is TypeInitializationException)
             {
-                throw new NotSupportedException("Due to conflicts between SixLabors.ImageSharp v2 and v3, to use SixLabors.ImageSharp v3 with Iron Software products please install IronSoftware.System.Drawing v.2023.4.1-prerelease NuGet package which supports SixLabors.ImageSharp v3.", e);
+                throw new NotSupportedException(IMAGE_SHARP_MISSING_METHOD_MESSAGE, e);
             }
         }
 
@@ -153,7 +159,7 @@ namespace IronSoftware.Drawing
             }
             catch (Exception e) when (e is MissingMethodException || e is TypeInitializationException)
             {
-                throw new NotSupportedException("Due to conflicts between SixLabors.ImageSharp v2 and v3, to use SixLabors.ImageSharp v3 with Iron Software products please install IronSoftware.System.Drawing v.2023.4.1-prerelease NuGet package which supports SixLabors.ImageSharp v3.", e);
+                throw new NotSupportedException(IMAGE_SHARP_MISSING_METHOD_MESSAGE, e);
             }
         }
 
@@ -176,7 +182,7 @@ namespace IronSoftware.Drawing
             }
             catch (Exception e) when (e is MissingMethodException || e is TypeInitializationException)
             {
-                throw new NotSupportedException("Due to conflicts between SixLabors.ImageSharp v2 and v3, to use SixLabors.ImageSharp v3 with Iron Software products please install IronSoftware.System.Drawing v.2023.4.1-prerelease NuGet package which supports SixLabors.ImageSharp v3.", e);
+                throw new NotSupportedException(IMAGE_SHARP_MISSING_METHOD_MESSAGE, e);
             }
         }
 
@@ -202,7 +208,7 @@ namespace IronSoftware.Drawing
             }
             catch (Exception e) when (e is MissingMethodException || e is TypeInitializationException)
             {
-                throw new NotSupportedException("Due to conflicts between SixLabors.ImageSharp v2 and v3, to use SixLabors.ImageSharp v3 with Iron Software products please install IronSoftware.System.Drawing v.2023.4.1-prerelease NuGet package which supports SixLabors.ImageSharp v3.", e);
+                throw new NotSupportedException(IMAGE_SHARP_MISSING_METHOD_MESSAGE, e);
             }
         }
 
@@ -224,7 +230,7 @@ namespace IronSoftware.Drawing
             }
             catch (Exception e) when (e is MissingMethodException || e is TypeInitializationException)
             {
-                throw new NotSupportedException("Due to conflicts between SixLabors.ImageSharp v2 and v3, to use SixLabors.ImageSharp v3 with Iron Software products please install IronSoftware.System.Drawing v.2023.4.1-prerelease NuGet package which supports SixLabors.ImageSharp v3.", e);
+                throw new NotSupportedException(IMAGE_SHARP_MISSING_METHOD_MESSAGE, e);
             }
         }
 
@@ -246,7 +252,7 @@ namespace IronSoftware.Drawing
             }
             catch (Exception e) when (e is MissingMethodException || e is TypeInitializationException)
             {
-                throw new NotSupportedException("Due to conflicts between SixLabors.ImageSharp v2 and v3, to use SixLabors.ImageSharp v3 with Iron Software products please install IronSoftware.System.Drawing v.2023.4.1-prerelease NuGet package which supports SixLabors.ImageSharp v3.", e);
+                throw new NotSupportedException(IMAGE_SHARP_MISSING_METHOD_MESSAGE, e);
             }
         }
 
@@ -303,7 +309,7 @@ namespace IronSoftware.Drawing
             }
             catch (Exception e) when (e is MissingMethodException || e is TypeInitializationException)
             {
-                throw new NotSupportedException("Due to conflicts between SixLabors.ImageSharp v2 and v3, to use SixLabors.ImageSharp v3 with Iron Software products please install IronSoftware.System.Drawing v.2023.4.1-prerelease NuGet package which supports SixLabors.ImageSharp v3.", e);
+                throw new NotSupportedException(IMAGE_SHARP_MISSING_METHOD_MESSAGE, e);
             }
         }
 
@@ -351,7 +357,7 @@ namespace IronSoftware.Drawing
             }
             catch (Exception e) when (e is MissingMethodException || e is TypeInitializationException)
             {
-                throw new NotSupportedException("Due to conflicts between SixLabors.ImageSharp v2 and v3, to use SixLabors.ImageSharp v3 with Iron Software products please install IronSoftware.System.Drawing v.2023.4.1-prerelease NuGet package which supports SixLabors.ImageSharp v3.", e);
+                throw new NotSupportedException(IMAGE_SHARP_MISSING_METHOD_MESSAGE, e);
             }
             catch
             {
@@ -375,7 +381,7 @@ namespace IronSoftware.Drawing
             }
             catch (Exception e) when (e is MissingMethodException || e is TypeInitializationException)
             {
-                throw new NotSupportedException("Due to conflicts between SixLabors.ImageSharp v2 and v3, to use SixLabors.ImageSharp v3 with Iron Software products please install IronSoftware.System.Drawing v.2023.4.1-prerelease NuGet package which supports SixLabors.ImageSharp v3.", e);
+                throw new NotSupportedException(IMAGE_SHARP_MISSING_METHOD_MESSAGE, e);
             }
             catch
             {
@@ -437,7 +443,7 @@ namespace IronSoftware.Drawing
             }
             catch (Exception e) when (e is MissingMethodException || e is TypeInitializationException)
             {
-                throw new NotSupportedException("Due to conflicts between SixLabors.ImageSharp v2 and v3, to use SixLabors.ImageSharp v3 with Iron Software products please install IronSoftware.System.Drawing v.2023.4.1-prerelease NuGet package which supports SixLabors.ImageSharp v3.", e);
+                throw new NotSupportedException(IMAGE_SHARP_MISSING_METHOD_MESSAGE, e);
             }
         }
         /// <summary>
@@ -455,7 +461,7 @@ namespace IronSoftware.Drawing
             }
             catch (Exception e) when (e is MissingMethodException || e is TypeInitializationException)
             {
-                throw new NotSupportedException("Due to conflicts between SixLabors.ImageSharp v2 and v3, to use SixLabors.ImageSharp v3 with Iron Software products please install IronSoftware.System.Drawing v.2023.4.1-prerelease NuGet package which supports SixLabors.ImageSharp v3.", e);
+                throw new NotSupportedException(IMAGE_SHARP_MISSING_METHOD_MESSAGE, e);
             }
         }
 
@@ -495,7 +501,7 @@ namespace IronSoftware.Drawing
             }
             catch (Exception e) when (e is MissingMethodException || e is TypeInitializationException)
             {
-                throw new NotSupportedException("Due to conflicts between SixLabors.ImageSharp v2 and v3, to use SixLabors.ImageSharp v3 with Iron Software products please install IronSoftware.System.Drawing v.2023.4.1-prerelease NuGet package which supports SixLabors.ImageSharp v3.", e);
+                throw new NotSupportedException(IMAGE_SHARP_MISSING_METHOD_MESSAGE, e);
             }
         }
 
@@ -513,7 +519,7 @@ namespace IronSoftware.Drawing
             }
             catch (Exception e) when (e is MissingMethodException || e is TypeInitializationException)
             {
-                throw new NotSupportedException("Due to conflicts between SixLabors.ImageSharp v2 and v3, to use SixLabors.ImageSharp v3 with Iron Software products please install IronSoftware.System.Drawing v.2023.4.1-prerelease NuGet package which supports SixLabors.ImageSharp v3.", e);
+                throw new NotSupportedException(IMAGE_SHARP_MISSING_METHOD_MESSAGE, e);
             }
         }
 
@@ -531,7 +537,7 @@ namespace IronSoftware.Drawing
             }
             catch (Exception e) when (e is MissingMethodException || e is TypeInitializationException)
             {
-                throw new NotSupportedException("Due to conflicts between SixLabors.ImageSharp v2 and v3, to use SixLabors.ImageSharp v3 with Iron Software products please install IronSoftware.System.Drawing v.2023.4.1-prerelease NuGet package which supports SixLabors.ImageSharp v3.", e);
+                throw new NotSupportedException(IMAGE_SHARP_MISSING_METHOD_MESSAGE, e);
             }
         }
 
@@ -567,7 +573,7 @@ namespace IronSoftware.Drawing
             }
             catch (Exception e) when (e is MissingMethodException || e is TypeInitializationException)
             {
-                throw new NotSupportedException("Due to conflicts between SixLabors.ImageSharp v2 and v3, to use SixLabors.ImageSharp v3 with Iron Software products please install IronSoftware.System.Drawing v.2023.4.1-prerelease NuGet package which supports SixLabors.ImageSharp v3.", e);
+                throw new NotSupportedException(IMAGE_SHARP_MISSING_METHOD_MESSAGE, e);
             }
         }
 
@@ -648,7 +654,7 @@ namespace IronSoftware.Drawing
                 }
                 catch (Exception e) when (e is MissingMethodException || e is TypeInitializationException)
                 {
-                    throw new NotSupportedException("Due to conflicts between SixLabors.ImageSharp v2 and v3, to use SixLabors.ImageSharp v3 with Iron Software products please install IronSoftware.System.Drawing v.2023.4.1-prerelease NuGet package which supports SixLabors.ImageSharp v3.", e);
+                    throw new NotSupportedException(IMAGE_SHARP_MISSING_METHOD_MESSAGE, e);
                 }
             }
         }
@@ -668,7 +674,7 @@ namespace IronSoftware.Drawing
                 }
                 catch (Exception e) when (e is MissingMethodException || e is TypeInitializationException)
                 {
-                    throw new NotSupportedException("Due to conflicts between SixLabors.ImageSharp v2 and v3, to use SixLabors.ImageSharp v3 with Iron Software products please install IronSoftware.System.Drawing v.2023.4.1-prerelease NuGet package which supports SixLabors.ImageSharp v3.", e);
+                    throw new NotSupportedException(IMAGE_SHARP_MISSING_METHOD_MESSAGE, e);
                 }
             }
         }
@@ -696,7 +702,7 @@ namespace IronSoftware.Drawing
                     }
                     catch (Exception e) when (e is MissingMethodException || e is TypeInitializationException)
                     {
-                        throw new NotSupportedException("Due to conflicts between SixLabors.ImageSharp v2 and v3, to use SixLabors.ImageSharp v3 with Iron Software products please install IronSoftware.System.Drawing v.2023.4.1-prerelease NuGet package which supports SixLabors.ImageSharp v3.", e);
+                        throw new NotSupportedException(IMAGE_SHARP_MISSING_METHOD_MESSAGE, e);
                     }
 
                     return images;
@@ -726,7 +732,7 @@ namespace IronSoftware.Drawing
             }
             catch (Exception e) when (e is MissingMethodException || e is TypeInitializationException)
             {
-                throw new NotSupportedException("Due to conflicts between SixLabors.ImageSharp v2 and v3, to use SixLabors.ImageSharp v3 with Iron Software products please install IronSoftware.System.Drawing v.2023.4.1-prerelease NuGet package which supports SixLabors.ImageSharp v3.", e);
+                throw new NotSupportedException(IMAGE_SHARP_MISSING_METHOD_MESSAGE, e);
             }
         }
 
@@ -748,7 +754,7 @@ namespace IronSoftware.Drawing
             }
             catch (Exception e) when (e is MissingMethodException || e is TypeInitializationException)
             {
-                throw new NotSupportedException("Due to conflicts between SixLabors.ImageSharp v2 and v3, to use SixLabors.ImageSharp v3 with Iron Software products please install IronSoftware.System.Drawing v.2023.4.1-prerelease NuGet package which supports SixLabors.ImageSharp v3.", e);
+                throw new NotSupportedException(IMAGE_SHARP_MISSING_METHOD_MESSAGE, e);
             }
         }
 
@@ -770,7 +776,7 @@ namespace IronSoftware.Drawing
             }
             catch (Exception e) when (e is MissingMethodException || e is TypeInitializationException)
             {
-                throw new NotSupportedException("Due to conflicts between SixLabors.ImageSharp v2 and v3, to use SixLabors.ImageSharp v3 with Iron Software products please install IronSoftware.System.Drawing v.2023.4.1-prerelease NuGet package which supports SixLabors.ImageSharp v3.", e);
+                throw new NotSupportedException(IMAGE_SHARP_MISSING_METHOD_MESSAGE, e);
             }
         }
 
@@ -792,7 +798,7 @@ namespace IronSoftware.Drawing
             }
             catch (Exception e) when (e is MissingMethodException || e is TypeInitializationException)
             {
-                throw new NotSupportedException("Due to conflicts between SixLabors.ImageSharp v2 and v3, to use SixLabors.ImageSharp v3 with Iron Software products please install IronSoftware.System.Drawing v.2023.4.1-prerelease NuGet package which supports SixLabors.ImageSharp v3.", e);
+                throw new NotSupportedException(IMAGE_SHARP_MISSING_METHOD_MESSAGE, e);
             }
         }
         
@@ -810,7 +816,7 @@ namespace IronSoftware.Drawing
             }
             catch (Exception e) when (e is MissingMethodException || e is TypeInitializationException)
             {
-                throw new NotSupportedException("Due to conflicts between SixLabors.ImageSharp v2 and v3, to use SixLabors.ImageSharp v3 with Iron Software products please install IronSoftware.System.Drawing v.2023.4.1-prerelease NuGet package which supports SixLabors.ImageSharp v3.", e);
+                throw new NotSupportedException(IMAGE_SHARP_MISSING_METHOD_MESSAGE, e);
             }
         }
         
@@ -829,7 +835,7 @@ namespace IronSoftware.Drawing
             }
             catch (Exception e) when (e is MissingMethodException || e is TypeInitializationException)
             {
-                throw new NotSupportedException("Due to conflicts between SixLabors.ImageSharp v2 and v3, to use SixLabors.ImageSharp v3 with Iron Software products please install IronSoftware.System.Drawing v.2023.4.1-prerelease NuGet package which supports SixLabors.ImageSharp v3.", e);
+                throw new NotSupportedException(IMAGE_SHARP_MISSING_METHOD_MESSAGE, e);
             }
         }
 
@@ -875,7 +881,7 @@ namespace IronSoftware.Drawing
             }
             catch (Exception e) when (e is MissingMethodException || e is TypeInitializationException)
             {
-                throw new NotSupportedException("Due to conflicts between SixLabors.ImageSharp v2 and v3, to use SixLabors.ImageSharp v3 with Iron Software products please install IronSoftware.System.Drawing v.2023.4.1-prerelease NuGet package which supports SixLabors.ImageSharp v3.", e);
+                throw new NotSupportedException(IMAGE_SHARP_MISSING_METHOD_MESSAGE, e);
             }
         }
 
@@ -893,7 +899,7 @@ namespace IronSoftware.Drawing
             }
             catch (Exception e) when (e is MissingMethodException || e is TypeInitializationException)
             {
-                throw new NotSupportedException("Due to conflicts between SixLabors.ImageSharp v2 and v3, to use SixLabors.ImageSharp v3 with Iron Software products please install IronSoftware.System.Drawing v.2023.4.1-prerelease NuGet package which supports SixLabors.ImageSharp v3.", e);
+                throw new NotSupportedException(IMAGE_SHARP_MISSING_METHOD_MESSAGE, e);
             }
         }
 
@@ -923,7 +929,7 @@ namespace IronSoftware.Drawing
             }
             catch (Exception e) when (e is MissingMethodException || e is TypeInitializationException)
             {
-                throw new NotSupportedException("Due to conflicts between SixLabors.ImageSharp v2 and v3, to use SixLabors.ImageSharp v3 with Iron Software products please install IronSoftware.System.Drawing v.2023.4.1-prerelease NuGet package which supports SixLabors.ImageSharp v3.", e);
+                throw new NotSupportedException(IMAGE_SHARP_MISSING_METHOD_MESSAGE, e);
             }
         }
 
@@ -940,7 +946,7 @@ namespace IronSoftware.Drawing
                 }
                 catch (Exception e) when (e is MissingMethodException || e is TypeInitializationException)
                 {
-                    throw new NotSupportedException("Due to conflicts between SixLabors.ImageSharp v2 and v3, to use SixLabors.ImageSharp v3 with Iron Software products please install IronSoftware.System.Drawing v.2023.4.1-prerelease NuGet package which supports SixLabors.ImageSharp v3.", e);
+                    throw new NotSupportedException(IMAGE_SHARP_MISSING_METHOD_MESSAGE, e);
                 }
             }
         }
@@ -959,7 +965,7 @@ namespace IronSoftware.Drawing
                 }
                 catch (Exception e) when (e is MissingMethodException || e is TypeInitializationException)
                 {
-                    throw new NotSupportedException("Due to conflicts between SixLabors.ImageSharp v2 and v3, to use SixLabors.ImageSharp v3 with Iron Software products please install IronSoftware.System.Drawing v.2023.4.1-prerelease NuGet package which supports SixLabors.ImageSharp v3.", e);
+                    throw new NotSupportedException(IMAGE_SHARP_MISSING_METHOD_MESSAGE, e);
                 }
             }
         }
@@ -978,7 +984,7 @@ namespace IronSoftware.Drawing
                 }
                 catch (Exception e) when (e is MissingMethodException || e is TypeInitializationException)
                 {
-                    throw new NotSupportedException("Due to conflicts between SixLabors.ImageSharp v2 and v3, to use SixLabors.ImageSharp v3 with Iron Software products please install IronSoftware.System.Drawing v.2023.4.1-prerelease NuGet package which supports SixLabors.ImageSharp v3.", e);
+                    throw new NotSupportedException(IMAGE_SHARP_MISSING_METHOD_MESSAGE, e);
                 }
             }
         }
@@ -1004,7 +1010,7 @@ namespace IronSoftware.Drawing
             }
             catch (Exception e) when (e is MissingMethodException || e is TypeInitializationException)
             {
-                throw new NotSupportedException("Due to conflicts between SixLabors.ImageSharp v2 and v3, to use SixLabors.ImageSharp v3 with Iron Software products please install IronSoftware.System.Drawing v.2023.4.1-prerelease NuGet package which supports SixLabors.ImageSharp v3.", e);
+                throw new NotSupportedException(IMAGE_SHARP_MISSING_METHOD_MESSAGE, e);
             }
         }
 
@@ -1022,7 +1028,7 @@ namespace IronSoftware.Drawing
                 }
                 catch (Exception e) when (e is MissingMethodException || e is TypeInitializationException)
                 {
-                    throw new NotSupportedException("Due to conflicts between SixLabors.ImageSharp v2 and v3, to use SixLabors.ImageSharp v3 with Iron Software products please install IronSoftware.System.Drawing v.2023.4.1-prerelease NuGet package which supports SixLabors.ImageSharp v3.", e);
+                    throw new NotSupportedException(IMAGE_SHARP_MISSING_METHOD_MESSAGE, e);
                 }
             }
         }
@@ -1041,7 +1047,7 @@ namespace IronSoftware.Drawing
                 }
                 catch (Exception e) when (e is MissingMethodException || e is TypeInitializationException)
                 {
-                    throw new NotSupportedException("Due to conflicts between SixLabors.ImageSharp v2 and v3, to use SixLabors.ImageSharp v3 with Iron Software products please install IronSoftware.System.Drawing v.2023.4.1-prerelease NuGet package which supports SixLabors.ImageSharp v3.", e);
+                    throw new NotSupportedException(IMAGE_SHARP_MISSING_METHOD_MESSAGE, e);
                 }
             }
         }
@@ -1070,7 +1076,7 @@ namespace IronSoftware.Drawing
             }
             catch (Exception e) when (e is MissingMethodException || e is TypeInitializationException)
             {
-                throw new NotSupportedException("Due to conflicts between SixLabors.ImageSharp v2 and v3, to use SixLabors.ImageSharp v3 with Iron Software products please install IronSoftware.System.Drawing v.2023.4.1-prerelease NuGet package which supports SixLabors.ImageSharp v3.", e);
+                throw new NotSupportedException(IMAGE_SHARP_MISSING_METHOD_MESSAGE, e);
             }
         }
 
@@ -1097,7 +1103,7 @@ namespace IronSoftware.Drawing
             }
             catch (Exception e) when (e is MissingMethodException || e is TypeInitializationException)
             {
-                throw new NotSupportedException("Due to conflicts between SixLabors.ImageSharp v2 and v3, to use SixLabors.ImageSharp v3 with Iron Software products please install IronSoftware.System.Drawing v.2023.4.1-prerelease NuGet package which supports SixLabors.ImageSharp v3.", e);
+                throw new NotSupportedException(IMAGE_SHARP_MISSING_METHOD_MESSAGE, e);
             }
             catch (Exception e)
             {
@@ -1122,7 +1128,7 @@ namespace IronSoftware.Drawing
             }
             catch (Exception e) when (e is MissingMethodException || e is TypeInitializationException)
             {
-                throw new NotSupportedException("Due to conflicts between SixLabors.ImageSharp v2 and v3, to use SixLabors.ImageSharp v3 with Iron Software products please install IronSoftware.System.Drawing v.2023.4.1-prerelease NuGet package which supports SixLabors.ImageSharp v3.", e);
+                throw new NotSupportedException(IMAGE_SHARP_MISSING_METHOD_MESSAGE, e);
             }
             catch (Exception e)
             {
@@ -1153,7 +1159,7 @@ namespace IronSoftware.Drawing
             }
             catch (Exception e) when (e is MissingMethodException || e is TypeInitializationException)
             {
-                throw new NotSupportedException("Due to conflicts between SixLabors.ImageSharp v2 and v3, to use SixLabors.ImageSharp v3 with Iron Software products please install IronSoftware.System.Drawing v.2023.4.1-prerelease NuGet package which supports SixLabors.ImageSharp v3.", e);
+                throw new NotSupportedException(IMAGE_SHARP_MISSING_METHOD_MESSAGE, e);
             }
             catch (Exception e)
             {
@@ -1178,7 +1184,7 @@ namespace IronSoftware.Drawing
             }
             catch (Exception e) when (e is MissingMethodException || e is TypeInitializationException)
             {
-                throw new NotSupportedException("Due to conflicts between SixLabors.ImageSharp v2 and v3, to use SixLabors.ImageSharp v3 with Iron Software products please install IronSoftware.System.Drawing v.2023.4.1-prerelease NuGet package which supports SixLabors.ImageSharp v3.", e);
+                throw new NotSupportedException(IMAGE_SHARP_MISSING_METHOD_MESSAGE, e);
             }
             catch (Exception e)
             {
@@ -1209,7 +1215,7 @@ namespace IronSoftware.Drawing
             }
             catch (Exception e) when (e is MissingMethodException || e is TypeInitializationException)
             {
-                throw new NotSupportedException("Due to conflicts between SixLabors.ImageSharp v2 and v3, to use SixLabors.ImageSharp v3 with Iron Software products please install IronSoftware.System.Drawing v.2023.4.1-prerelease NuGet package which supports SixLabors.ImageSharp v3.", e);
+                throw new NotSupportedException(IMAGE_SHARP_MISSING_METHOD_MESSAGE, e);
             }
             catch (Exception e)
             {
@@ -1234,7 +1240,7 @@ namespace IronSoftware.Drawing
             }
             catch (Exception e) when (e is MissingMethodException || e is TypeInitializationException)
             {
-                throw new NotSupportedException("Due to conflicts between SixLabors.ImageSharp v2 and v3, to use SixLabors.ImageSharp v3 with Iron Software products please install IronSoftware.System.Drawing v.2023.4.1-prerelease NuGet package which supports SixLabors.ImageSharp v3.", e);
+                throw new NotSupportedException(IMAGE_SHARP_MISSING_METHOD_MESSAGE, e);
             }
             catch (Exception e)
             {
@@ -1808,7 +1814,7 @@ namespace IronSoftware.Drawing
             }
             catch (MissingMethodException e)
             {
-                throw new NotSupportedException("Due to conflicts between SixLabors.ImageSharp v2 and v3, to use SixLabors.ImageSharp v3 with Iron Software products please install IronSoftware.System.Drawing v.2023.4.1-prerelease NuGet package which supports SixLabors.ImageSharp v3.", e);
+                throw new NotSupportedException(IMAGE_SHARP_MISSING_METHOD_MESSAGE, e);
             }
             catch (Exception e)
             {
@@ -1842,7 +1848,7 @@ namespace IronSoftware.Drawing
             }
             catch (MissingMethodException e)
             {
-                throw new NotSupportedException("Due to conflicts between SixLabors.ImageSharp v2 and v3, to use SixLabors.ImageSharp v3 with Iron Software products please install IronSoftware.System.Drawing v.2023.4.1-prerelease NuGet package which supports SixLabors.ImageSharp v3.", e);
+                throw new NotSupportedException(IMAGE_SHARP_MISSING_METHOD_MESSAGE, e);
             }
             catch (Exception e)
             {
@@ -2294,7 +2300,7 @@ namespace IronSoftware.Drawing
             }
             catch (MissingMethodException e)
             {
-                throw new NotSupportedException("Due to conflicts between SixLabors.ImageSharp v2 and v3, to use SixLabors.ImageSharp v3 with Iron Software products please install IronSoftware.System.Drawing v.2023.4.1-prerelease NuGet package which supports SixLabors.ImageSharp v3.", e);
+                throw new NotSupportedException(IMAGE_SHARP_MISSING_METHOD_MESSAGE, e);
             }
             catch (Exception e)
             {

--- a/NuGet/IronSoftware.Drawing.nuspec
+++ b/NuGet/IronSoftware.Drawing.nuspec
@@ -36,8 +36,7 @@ Supports:
 
 For general support and technical inquiries, please email us at: developers@ironsoftware.com</description>
 		<summary>IronSoftware.System.Drawing is an open-source solution for .NET developers to replace System.Drawing.Common with a universal and flexible library.</summary>
-		<releaseNotes>- Added a deconstructor for the AnyBitmap class to automatically dispose of objects, simplifying memory management.
-- Added a new function call to the Color class: ToHtmlCssColorCode(). This translates the specified Color structure to an HTML string color representation.</releaseNotes>
+		<releaseNotes>* Add support message for the new version of SixLabors.</releaseNotes>
 		<copyright>Copyright © Iron Software 2022-2023</copyright>
 		<tags>Images, Bitmap, SkiaSharp, SixLabors, BitMiracle, Maui, SVG, TIFF, TIF, GIF, JPEG, PNG, Color, Rectangle, Drawing, C#, VB.NET, ASPX, create, render, generate, standard, netstandard2.0, core, netcore</tags>
 		<repository type="git" url="https://github.com/iron-software/IronSoftware.Drawing.Common" commit="$commit$" />


### PR DESCRIPTION
### Description
- Updated `MissingMethodException` or `TypeInitializationException` message to "Due to conflicts between SixLabors.ImageSharp v2 and v3, to use SixLabors.ImageSharp v3 with Iron Software products please install IronSoftware.System.Drawing v.2023.4.1-prerelease NuGet package which supports SixLabors.ImageSharp v3."
- Updated releasenotes

### Type of change
Please select the relevant option by placing an 'x' inside the brackets, like this: [x].

- [ ] 🐛 Bug fix (non-breaking change which fixes an issue)
- [ ] ✨ New feature (non-breaking change which adds functionality)
- [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] 🏗️ Internal/structural update (non-breaking change that improves code quality, organization, or performance)
- [X] 📚 This change requires a documentation update
- [ ] 🚀 DevOps build chain modification for release
- [ ] 🤖 DevOps build chain modification for CI

### How Has This Been Tested?
Run Unit tests locally.

### Checklist:
Please run through the checklist as much as possible and mark the items completed by placing an 'x' inside the brackets, like this: [x].

- [ ] My code follows the style guidelines of this project
- [X] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [X] New and existing unit tests pass locally with my changes
- [ ] I have successfully run all unit tests on Windows
- [ ] I have successfully run all unit tests on Linux

### Additional Context
Add any other context, screenshots, or information about the pull request here.
