### PR TITLE
Feature: Added methods to load AnyBitmap from RGB buffer and retrieve RGB buffer from image

### DIFF
--- a/IronSoftware.Drawing/IronSoftware.Drawing.Common.Tests/UnitTests/AnyBitmapFunctionality.cs
+++ b/IronSoftware.Drawing/IronSoftware.Drawing.Common.Tests/UnitTests/AnyBitmapFunctionality.cs
@@ -655,6 +655,73 @@ namespace IronSoftware.Drawing.Common.Tests.UnitTests
             }
         }
 
+        [FactWithAutomaticDisplayName]
+        public void TestGetRGBBuffer()
+        {
+            string imagePath = GetRelativeFilePath("checkmark.jpg");
+            using var bitmap = new AnyBitmap(imagePath);
+            var expectedSize = bitmap.Width * bitmap.Height * 3; // 3 bytes per pixel (RGB)
+
+            byte[] buffer = bitmap.GetRGBBuffer();
+
+            Assert.Equal(expectedSize, buffer.Length);
+
+            // Verify the first pixel's RGB values
+            var firstPixel = bitmap.GetPixel(0, 0);
+            Assert.Equal(firstPixel.R, buffer[0]);
+            Assert.Equal(firstPixel.G, buffer[1]);
+            Assert.Equal(firstPixel.B, buffer[2]);
+        }
+
+        [FactWithAutomaticDisplayName]
+        public void Test_LoadFromRGBBuffer()
+        {
+            // Arrange
+            int width = 2;
+            int height = 2;
+            byte[] buffer = new byte[]
+            {
+                255, 0, 0, // red
+                0, 255, 0, // green
+                0, 0, 255, // blue
+                255, 255, 255, // white
+            };
+
+            // Act
+            AnyBitmap result = AnyBitmap.LoadAnyBitmapFromRGBBuffer(buffer, width, height);
+
+            // Assert
+            byte[] resultData = result.GetRGBBuffer();
+            Assert.Equal(buffer, resultData);
+        }
+
+        [FactWithAutomaticDisplayName]
+        public void TestLoadAnyBitmapFromRGBBuffer()
+        {
+            string imagePath = GetRelativeFilePath("checkmark.jpg");
+
+            using var bitmap = SixLabors.ImageSharp.Image.Load<Rgb24>(imagePath);
+            var width = bitmap.Width;
+            var height = bitmap.Height;
+
+            var buffer = GetRGBBuffer(imagePath);
+
+            AnyBitmap result = AnyBitmap.LoadAnyBitmapFromRGBBuffer(buffer, width, height);
+
+            for (int y = 0; y < height; y++)
+            {
+                for (int x = 0; x < width; x++)
+                {
+                    var expectedColor = bitmap[x, y];
+                    var actualColor = result.GetPixel(x, y);
+
+                    Assert.Equal(expectedColor.R, actualColor.R);
+                    Assert.Equal(expectedColor.G, actualColor.G);
+                    Assert.Equal(expectedColor.B, actualColor.B);
+                }
+            }
+        }
+
 #if !NETFRAMEWORK
         [FactWithAutomaticDisplayName]
         public void CastMaui_to_AnyBitmap()

--- a/IronSoftware.Drawing/IronSoftware.Drawing.Common.Tests/UnitTests/Compare.cs
+++ b/IronSoftware.Drawing/IronSoftware.Drawing.Common.Tests/UnitTests/Compare.cs
@@ -1,4 +1,5 @@
-﻿using System;
+﻿using SixLabors.ImageSharp.PixelFormats;
+using System;
 using System.IO;
 using System.Linq;
 using System.Security.Cryptography;
@@ -155,6 +156,36 @@ namespace IronSoftware.Drawing.Common.Tests.UnitTests
             }
 
             return res;
+        }
+
+        protected byte[] GetRGBBuffer(string imagePath)
+        {
+            using var image = SixLabors.ImageSharp.Image.Load<Rgb24>(imagePath); // Load image from file
+
+            int width = image.Width;
+            int height = image.Height;
+
+            byte[] rgbBuffer = new byte[width * height * 3]; // 3 bytes per pixel (RGB)
+
+            image.ProcessPixelRows(accessor =>
+            {
+                for (int y = 0; y < accessor.Height; y++)
+                {
+                    Span<Rgb24> pixelRow = accessor.GetRowSpan(y);
+
+                    for (int x = 0; x < accessor.Width; x++)
+                    {
+                        ref Rgb24 pixel = ref pixelRow[x];
+
+                        int bufferIndex = (y * width + x) * 3;
+                        rgbBuffer[bufferIndex] = pixel.R;
+                        rgbBuffer[bufferIndex + 1] = pixel.G;
+                        rgbBuffer[bufferIndex + 2] = pixel.B;
+                    }
+                }
+            });
+
+            return rgbBuffer;
         }
     }
 }

--- a/NuGet/IronSoftware.Drawing.nuspec
+++ b/NuGet/IronSoftware.Drawing.nuspec
@@ -36,9 +36,8 @@ Supports:
 
 For general support and technical inquiries, please email us at: developers@ironsoftware.com</description>
 		<summary>IronSoftware.System.Drawing is an open-source solution for .NET developers to replace System.Drawing.Common with a universal and flexible library.</summary>
-		<releaseNotes>- Adds explicit dependency on System.Memory 4.5.5
-- Updates other dependencies
-- BREAKING CHANGE: if a developer is using method parameter names of public API of this package in their code - there will be design-time errors after this update, due to these parameters being refactored to follow camelCase naming schema.</releaseNotes>
+		<releaseNotes>- Added LoadAnyBitmapFromRGBBuffer method: This new feature allows you to create an AnyBitmap object directly from an RGB pixel data buffer, providing a straightforward way to convert byte arrays into AnyBitmap objects.
+- Added GetRGBBuffer method: This enhancement simplifies the process of retrieving an RGB buffer from an image. You can now obtain the RGB pixel data from any image with a single method call.</releaseNotes>
 		<copyright>Copyright © Iron Software 2022-2023</copyright>
 		<tags>Images, Bitmap, SkiaSharp, SixLabors, BitMiracle, Maui, SVG, TIFF, TIF, GIF, JPEG, PNG, Color, Rectangle, Drawing, C#, VB.NET, ASPX, create, render, generate, standard, netstandard2.0, core, netcore</tags>
 		<repository type="git" url="https://github.com/iron-software/IronSoftware.Drawing.Common" commit="$commit$" />


### PR DESCRIPTION
### Description
In this PR, two new methods were implemented:

`LoadAnyBitmapFromRGBBuffer`: This method creates an AnyBitmap object from a provided buffer of RGB pixel data. It takes in a byte array, along with width and height parameters, and returns an AnyBitmap object.
```
byte[] buffer = YOUR_RGB_BUFFER;
using AnyBitmap result = AnyBitmap.LoadAnyBitmapFromRGBBuffer(buffer, width, height);
```

`GetRGBBuffer`: This method retrieves the RGB buffer from an AnyBitmap object. It returns an array of bytes representing the RGB buffer of the image.
```
using var bitmap = new AnyBitmap(YOUR_IMAGE_PATH);
byte[] buffer = bitmap.GetRGBBuffer();
```

These methods provide more flexibility when working with images and RGB data, simplifying the process of creating AnyBitmap objects from RGB buffers and retrieving RGB buffers from images.

Fixes #29 

### Type of change
Please select the relevant option by placing an 'x' inside the brackets, like this: [x].

- [ ] 🐛 Bug fix (non-breaking change which fixes an issue)
- [X] ✨ New feature (non-breaking change which adds functionality)
- [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] 🏗️ Internal/structural update (non-breaking change that improves code quality, organization, or performance)
- [X] 📚 This change requires a documentation update
- [ ] 🚀 DevOps build chain modification for release
- [ ] 🤖 DevOps build chain modification for CI

### How Has This Been Tested?
Describe the tests you ran to verify your changes. Provide instructions so others can reproduce the tests. Also, list any relevant details for your test configuration.

### Checklist:
Please run through the checklist as much as possible and mark the items completed by placing an 'x' inside the brackets, like this: [x].

- [ ] My code follows the style guidelines of this project
- [X] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [X] My changes generate no new warnings
- [X] I have added tests that prove my fix is effective or that my feature works
- [X] New and existing unit tests pass locally with my changes
- [X] I have successfully run all unit tests on Windows
- [X] I have successfully run all unit tests on Linux
