### PR TITLE
Implement color get brightness & create blank image

### DIFF
--- a/IronSoftware.Drawing/IronSoftware.Drawing.Common.Tests/UnitTests/AnyBitmapFunctionality.cs
+++ b/IronSoftware.Drawing/IronSoftware.Drawing.Common.Tests/UnitTests/AnyBitmapFunctionality.cs
@@ -789,5 +789,18 @@ namespace IronSoftware.Drawing.Common.Tests.UnitTests
             anyBitmap.FrameCount.Should().BeGreaterThan(0);
         }
 
+        [FactWithAutomaticDisplayName]
+        public void Create_New_Image_Instance()
+        {
+            string blankBitmapPath = "blank_bitmap.bmp";
+            var bitmap = new AnyBitmap(8, 8);
+            bitmap.SaveAs(blankBitmapPath);
+
+            AnyBitmap blankBitmap = AnyBitmap.FromFile(blankBitmapPath);
+
+            blankBitmap.Width.Should().Be(8);
+            blankBitmap.Height.Should().Be(8);
+        }
+
     }
 }

--- a/IronSoftware.Drawing/IronSoftware.Drawing.Common.Tests/UnitTests/ColorFunctionality.cs
+++ b/IronSoftware.Drawing/IronSoftware.Drawing.Common.Tests/UnitTests/ColorFunctionality.cs
@@ -615,6 +615,20 @@ namespace IronSoftware.Drawing.Common.Tests.UnitTests
             Assert.Equal(expectedHtml, actualHtml);
         }
 
+        [Theory]
+        [InlineData(0, 0, 0, 0.0)]     // Black
+        [InlineData(255, 255, 255, 1.0)] // White
+        [InlineData(255, 0, 0, 1.0)]     // Red
+        [InlineData(0, 255, 0, 1.0)]     // Green
+        [InlineData(0, 0, 255, 1.0)]     // Blue
+        [InlineData(127, 127, 127, 0.4980392156862745)] // Gray
+        public void TestBrightness(byte red, byte green, byte blue, double expectedBrightness)
+        {
+            Color color = Color.FromArgb(red, green, blue);
+            double brightness = color.GetBrightness();
+            Assert.Equal(expectedBrightness, brightness, 5);
+        }
+
 #if !NETFRAMEWORK
         [FactWithAutomaticDisplayName]
         public void Cast_Maui_from_Color()

--- a/IronSoftware.Drawing/IronSoftware.Drawing.Common/AnyBitmap.cs
+++ b/IronSoftware.Drawing/IronSoftware.Drawing.Common/AnyBitmap.cs
@@ -1,7 +1,6 @@
 ﻿using BitMiracle.LibTiff.Classic;
 using Microsoft.Maui.Graphics.Platform;
 using SixLabors.ImageSharp;
-using SixLabors.ImageSharp.Advanced;
 using SixLabors.ImageSharp.Drawing.Processing;
 using SixLabors.ImageSharp.Formats;
 using SixLabors.ImageSharp.Formats.Bmp;
@@ -558,6 +557,17 @@ namespace IronSoftware.Drawing
             {
                 throw new NotSupportedException("Error while loading AnyBitmap from Uri", e);
             }
+        }
+
+        /// <summary>
+        /// Construct a new Bitmap from width and height
+        /// </summary>
+        /// <param name="width">Width of new AnyBitmap</param>
+        /// <param name="height">Height of new AnyBitmap</param>
+        /// <param name="backgrounColor">Background color of new AnyBitmap</param>
+        public AnyBitmap(int width, int height, Color backgrounColor = null)
+        {
+            CreateNewImageInstance(width, height, backgrounColor);
         }
 
         /// <summary>
@@ -1878,6 +1888,18 @@ namespace IronSoftware.Drawing
         }
 
         #region Private Method
+
+        private void CreateNewImageInstance(int width, int height, Color backgrounColor)
+        {
+            Image = new Image<Rgba32>(width, height);
+            if (backgrounColor != null)
+            {
+                Image.Mutate(context => context.Fill(backgrounColor));
+            }
+            using var stream = new MemoryStream();
+            Image.SaveAsBmp(stream);
+            Binary = stream.ToArray();
+        }
 
         private void LoadImage(byte[] bytes)
         {

--- a/IronSoftware.Drawing/IronSoftware.Drawing.Common/Color.cs
+++ b/IronSoftware.Drawing/IronSoftware.Drawing.Common/Color.cs
@@ -926,6 +926,16 @@ namespace IronSoftware.Drawing
         }
 
         /// <summary>
+        /// Calculates the brightness of a color.
+        /// </summary>
+        /// <returns>The brightness of the color, a value between 0 (black) and 1 (white).</returns>
+        public double GetBrightness()
+        {
+            byte max = Math.Max(R, Math.Max(G, B));
+            return max / 255.0;
+        }
+
+        /// <summary>
         /// Gets the 32-bit ARGB value of this <see cref="Color"/> structure.
         /// <br/><para><b>Further Documentation:</b><br/><a href="https://ironsoftware.com/open-source/csharp/drawing/examples/convert-color-to-32-bit-argb-value/">Code Example</a></para>
         /// </summary>

--- a/NuGet/IronSoftware.Drawing.nuspec
+++ b/NuGet/IronSoftware.Drawing.nuspec
@@ -36,7 +36,7 @@ Supports:
 
 For general support and technical inquiries, please email us at: developers@ironsoftware.com</description>
 		<summary>IronSoftware.System.Drawing is an open-source solution for .NET developers to replace System.Drawing.Common with a universal and flexible library.</summary>
-		<releaseNotes>- Added AnyBitmap constructure to create blank image from width and height
+		<releaseNotes>- Added AnyBitmap constructor to create blank image from width and height
 - Added Color.GetBrightness to calculates the brightness of a color</releaseNotes>
 		<copyright>Copyright © Iron Software 2022-2023</copyright>
 		<tags>Images, Bitmap, SkiaSharp, SixLabors, BitMiracle, Maui, SVG, TIFF, TIF, GIF, JPEG, PNG, Color, Rectangle, Drawing, C#, VB.NET, ASPX, create, render, generate, standard, netstandard2.0, core, netcore</tags>

--- a/NuGet/IronSoftware.Drawing.nuspec
+++ b/NuGet/IronSoftware.Drawing.nuspec
@@ -37,7 +37,7 @@ Supports:
 For general support and technical inquiries, please email us at: developers@ironsoftware.com</description>
 		<summary>IronSoftware.System.Drawing is an open-source solution for .NET developers to replace System.Drawing.Common with a universal and flexible library.</summary>
 		<releaseNotes>- Added AnyBitmap constructor to create blank image from width and height
-- Added Color.GetBrightness to calculates the brightness of a color</releaseNotes>
+- Added Color.GetBrightness to calculate the brightness of a color</releaseNotes>
 		<copyright>Copyright © Iron Software 2022-2023</copyright>
 		<tags>Images, Bitmap, SkiaSharp, SixLabors, BitMiracle, Maui, SVG, TIFF, TIF, GIF, JPEG, PNG, Color, Rectangle, Drawing, C#, VB.NET, ASPX, create, render, generate, standard, netstandard2.0, core, netcore</tags>
 		<repository type="git" url="https://github.com/iron-software/IronSoftware.Drawing.Common" commit="$commit$" />

--- a/NuGet/IronSoftware.Drawing.nuspec
+++ b/NuGet/IronSoftware.Drawing.nuspec
@@ -36,8 +36,8 @@ Supports:
 
 For general support and technical inquiries, please email us at: developers@ironsoftware.com</description>
 		<summary>IronSoftware.System.Drawing is an open-source solution for .NET developers to replace System.Drawing.Common with a universal and flexible library.</summary>
-		<releaseNotes>- Added Point and PointF classes
-- Added a SetPixel method to AnyBitmap to set a pixel's color</releaseNotes>
+		<releaseNotes>- Added AnyBitmap constructure to create blank image from width and height
+- Added Color.GetBrightness to calculates the brightness of a color</releaseNotes>
 		<copyright>Copyright © Iron Software 2022-2023</copyright>
 		<tags>Images, Bitmap, SkiaSharp, SixLabors, BitMiracle, Maui, SVG, TIFF, TIF, GIF, JPEG, PNG, Color, Rectangle, Drawing, C#, VB.NET, ASPX, create, render, generate, standard, netstandard2.0, core, netcore</tags>
 		<repository type="git" url="https://github.com/iron-software/IronSoftware.Drawing.Common" commit="$commit$" />


### PR DESCRIPTION
### Description
- Add AnyBitmap constructor to creating blank image
```csharp
var bitmap = new AnyBitmap(8, 8);
bitmap.SaveAs("blank_bitmap.jpg");
```
- Add GetBrightness to calculates the brightness of a color.
```csharp
Color color = Color.Black;
double brightness = color.GetBrightness();
```

Fixes #(issue number)
If this PR addresses an existing issue, mention the issue number here.

### Type of change
Please select the relevant option by placing an 'x' inside the brackets, like this: [x].

- [ ] 🐛 Bug fix (non-breaking change which fixes an issue)
- [X] ✨ New feature (non-breaking change which adds functionality)
- [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] 🏗️ Internal/structural update (non-breaking change that improves code quality, organization, or performance)
- [ ] 📚 This change requires a documentation update
- [ ] 🚀 DevOps build chain modification for release
- [ ] 🤖 DevOps build chain modification for CI

### How Has This Been Tested?
Add unit tests to test each function.

### Checklist:
Please run through the checklist as much as possible and mark the items completed by placing an 'x' inside the brackets, like this: [x].

- [X] My code follows the style guidelines of this project
- [X] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [X] My changes generate no new warnings
- [X] I have added tests that prove my fix is effective or that my feature works
- [X] New and existing unit tests pass locally with my changes
- [X] I have successfully run all unit tests on Windows
- [X] I have successfully run all unit tests on Linux
