### PR TITLE
Hotfix September RC

### DIFF
--- a/IronSoftware.Drawing/IronSoftware.Drawing.Common.Tests/IronSoftware.Drawing.Common.Tests.csproj
+++ b/IronSoftware.Drawing/IronSoftware.Drawing.Common.Tests/IronSoftware.Drawing.Common.Tests.csproj
@@ -12,7 +12,7 @@
 	<ItemGroup>
 		<PackageReference Include="FluentAssertions" Version="6.10.0" />
 		<PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.5.0" />
-		<PackageReference Include="SixLabors.ImageSharp.Drawing" Version="1.0.0-beta15" />
+		<PackageReference Include="SixLabors.ImageSharp.Drawing" Version="1.0.0" />
 		<PackageReference Include="Microsoft.Maui.Graphics" Version="7.0.81" />
 		<PackageReference Include="SkiaSharp" Version="2.88.3" />
 		<PackageReference Include="System.Drawing.Common" Version="5.0.3" />

--- a/IronSoftware.Drawing/IronSoftware.Drawing.Common.Tests/UnitTests/AnyBitmapFunctionality.cs
+++ b/IronSoftware.Drawing/IronSoftware.Drawing.Common.Tests/UnitTests/AnyBitmapFunctionality.cs
@@ -803,6 +803,26 @@ namespace IronSoftware.Drawing.Common.Tests.UnitTests
         }
 
         [FactWithAutomaticDisplayName]
+        public void Create_New_Image_With_Background_Instance()
+        {
+            string blankBitmapPath = "blank_bitmap.bmp";
+            var bitmap = new AnyBitmap(8, 8, Color.DarkRed);
+            bitmap.SaveAs(blankBitmapPath);
+
+            AnyBitmap blankBitmap = AnyBitmap.FromFile(blankBitmapPath);
+
+            blankBitmap.Width.Should().Be(8);
+            blankBitmap.Height.Should().Be(8);
+            for (int i = 0; i < 8; i++)
+            {
+                for (int j = 0; j < 8; j++)
+                {
+                    blankBitmap.GetPixel(i, j).Should().Be(Color.DarkRed);
+                }
+            }
+        }
+
+        [FactWithAutomaticDisplayName]
         public void ExtractAlphaData_With32bppImage_ReturnsAlphaChannel()
         {
             // Arrange

--- a/IronSoftware.Drawing/IronSoftware.Drawing.Common/IronSoftware.Drawing.Common.csproj
+++ b/IronSoftware.Drawing/IronSoftware.Drawing.Common/IronSoftware.Drawing.Common.csproj
@@ -24,7 +24,7 @@
 	<ItemGroup>
 		<PackageReference Include="BitMiracle.LibTiff.NET" Version="2.4.649" />
 		<PackageReference Include="Microsoft.Maui.Graphics" Version="7.0.81" />
-		<PackageReference Include="SixLabors.ImageSharp.Drawing" Version="1.0.0-beta15" />
+		<PackageReference Include="SixLabors.ImageSharp.Drawing" Version="1.0.0" />
 		<PackageReference Include="SkiaSharp" Version="2.88.3" />
 		<PackageReference Include="SkiaSharp.NativeAssets.Linux" Version="2.88.3" />
 		<PackageReference Include="SkiaSharp.Svg" Version="1.60.0" />
@@ -41,7 +41,7 @@
 		</When>
 		<Otherwise>
 			<ItemGroup>
-				<PackageReference Include="SixLabors.ImageSharp" Version="2.1.3" />
+				<PackageReference Include="SixLabors.ImageSharp" Version="2.1.5" />
 			</ItemGroup>
 		</Otherwise>
 	</Choose>

--- a/NuGet/IronSoftware.Drawing.nuspec
+++ b/NuGet/IronSoftware.Drawing.nuspec
@@ -44,17 +44,20 @@ For general support and technical inquiries, please email us at: developers@iron
 		<repository type="git" url="https://github.com/iron-software/IronSoftware.Drawing.Common" commit="$commit$" />
 		<dependencies>
 			<group targetFramework="netstandard2.0">
-				<dependency id="SixLabors.ImageSharp" version="2.1.3" />
+				<dependency id="SixLabors.ImageSharp" version="2.1.5" />
+				<dependency id="SixLabors.ImageSharp.Drawing" version="1.0.0" />
 				<dependency id="BitMiracle.LibTiff.NET" version="2.4.649" />
 				<dependency id="System.Memory" version="4.5.5" />
 			</group>
 			<group targetFramework="net60">
-				<dependency id="SixLabors.ImageSharp" version="3.0.0" />
+				<dependency id="SixLabors.ImageSharp" version="3.0.1" />
+				<dependency id="SixLabors.ImageSharp.Drawing" version="1.0.0" />
 				<dependency id="BitMiracle.LibTiff.NET" version="2.4.649" />
 				<dependency id="System.Memory" version="4.5.5" />
 			</group>
 			<group targetFramework="netstandard2.1">
-				<dependency id="SixLabors.ImageSharp" version="2.1.3" />
+				<dependency id="SixLabors.ImageSharp" version="2.1.5" />
+				<dependency id="SixLabors.ImageSharp.Drawing" version="1.0.0" />
 				<dependency id="BitMiracle.LibTiff.NET" version="2.4.649" />
 				<dependency id="System.Memory" version="4.5.5" />
 			</group>


### PR DESCRIPTION
### Description
- Fixed issue can't create blank image with Background color.
- Upgrade ImageSharp.Image (2.1.5 netstandard2.0 and netstandard2.1, 3.0.1 net6.0+) and ImageSharp.Drawing (1.0.0) to latest version.
- Now NuGet package including ImageSharp.Drawing (1.0.0) as dependency.

### Type of change
Please select the relevant option by placing an 'x' inside the brackets, like this: [x].

- [X] 🐛 Bug fix (non-breaking change which fixes an issue)
- [ ] ✨ New feature (non-breaking change which adds functionality)
- [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [X] 🏗️ Internal/structural update (non-breaking change that improves code quality, organization, or performance)
- [ ] 📚 This change requires a documentation update
- [ ] 🚀 DevOps build chain modification for release
- [ ] 🤖 DevOps build chain modification for CI

### How Has This Been Tested?
Create unit tests and also test the final package.

### Checklist:
Please run through the checklist as much as possible and mark the items completed by placing an 'x' inside the brackets, like this: [x].

- [X] My code follows the style guidelines of this project
- [X] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [X] I have added tests that prove my fix is effective or that my feature works
- [X] New and existing unit tests pass locally with my changes
- [X] I have successfully run all unit tests on Windows
- [X] I have successfully run all unit tests on Linux
