### PR TITLE
Fix mobile compatiblity

### DIFF
--- a/IronSoftware.Drawing/IronSoftware.Drawing.Common.Tests/IronSoftware.Drawing.Common.Tests.csproj
+++ b/IronSoftware.Drawing/IronSoftware.Drawing.Common.Tests/IronSoftware.Drawing.Common.Tests.csproj
@@ -13,7 +13,7 @@
 		<PackageReference Include="FluentAssertions" Version="6.10.0" />
 		<PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.5.0" />
 		<PackageReference Include="SixLabors.ImageSharp.Drawing" Version="1.0.0" />
-		<PackageReference Include="Microsoft.Maui.Graphics" Version="7.0.81" />
+		<PackageReference Include="Microsoft.Maui.Graphics" Version="7.0.92" />
 		<PackageReference Include="SkiaSharp" Version="2.88.5" />
 		<PackageReference Include="SkiaSharp.NativeAssets.Linux" Version="2.88.5" />
 		<PackageReference Include="System.Drawing.Common" Version="5.0.3" />

--- a/IronSoftware.Drawing/IronSoftware.Drawing.Common.Tests/IronSoftware.Drawing.Common.Tests.csproj
+++ b/IronSoftware.Drawing/IronSoftware.Drawing.Common.Tests/IronSoftware.Drawing.Common.Tests.csproj
@@ -15,6 +15,7 @@
 		<PackageReference Include="SixLabors.ImageSharp.Drawing" Version="1.0.0" />
 		<PackageReference Include="Microsoft.Maui.Graphics" Version="7.0.81" />
 		<PackageReference Include="SkiaSharp" Version="2.88.5" />
+		<PackageReference Include="SkiaSharp.NativeAssets.Linux" Version="2.88.5" />
 		<PackageReference Include="System.Drawing.Common" Version="5.0.3" />
 		<PackageReference Include="xunit" Version="2.4.2" />
 		<PackageReference Include="xunit.runner.visualstudio" Version="2.4.5">

--- a/IronSoftware.Drawing/IronSoftware.Drawing.Common.Tests/IronSoftware.Drawing.Common.Tests.csproj
+++ b/IronSoftware.Drawing/IronSoftware.Drawing.Common.Tests/IronSoftware.Drawing.Common.Tests.csproj
@@ -14,7 +14,7 @@
 		<PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.5.0" />
 		<PackageReference Include="SixLabors.ImageSharp.Drawing" Version="1.0.0" />
 		<PackageReference Include="Microsoft.Maui.Graphics" Version="7.0.81" />
-		<PackageReference Include="SkiaSharp" Version="2.88.3" />
+		<PackageReference Include="SkiaSharp" Version="2.88.5" />
 		<PackageReference Include="System.Drawing.Common" Version="5.0.3" />
 		<PackageReference Include="xunit" Version="2.4.2" />
 		<PackageReference Include="xunit.runner.visualstudio" Version="2.4.5">

--- a/IronSoftware.Drawing/IronSoftware.Drawing.Common/IronSoftware.Drawing.Common.csproj
+++ b/IronSoftware.Drawing/IronSoftware.Drawing.Common/IronSoftware.Drawing.Common.csproj
@@ -25,8 +25,7 @@
 		<PackageReference Include="BitMiracle.LibTiff.NET" Version="2.4.649" />
 		<PackageReference Include="Microsoft.Maui.Graphics" Version="7.0.81" />
 		<PackageReference Include="SixLabors.ImageSharp.Drawing" Version="1.0.0" />
-		<PackageReference Include="SkiaSharp" Version="2.88.3" />
-		<PackageReference Include="SkiaSharp.NativeAssets.Linux" Version="2.88.3" />
+		<PackageReference Include="SkiaSharp" Version="2.88.5" />
 		<PackageReference Include="SkiaSharp.Svg" Version="1.60.0" />
 		<PackageReference Include="System.Drawing.Common" Version="5.0.3" />
 		<PackageReference Include="System.Memory" Version="4.5.5" />

--- a/IronSoftware.Drawing/IronSoftware.Drawing.Common/IronSoftware.Drawing.Common.csproj
+++ b/IronSoftware.Drawing/IronSoftware.Drawing.Common/IronSoftware.Drawing.Common.csproj
@@ -23,7 +23,7 @@
 
 	<ItemGroup>
 		<PackageReference Include="BitMiracle.LibTiff.NET" Version="2.4.649" />
-		<PackageReference Include="Microsoft.Maui.Graphics" Version="7.0.81" />
+		<PackageReference Include="Microsoft.Maui.Graphics" Version="7.0.92" />
 		<PackageReference Include="SixLabors.ImageSharp.Drawing" Version="1.0.0" />
 		<PackageReference Include="SkiaSharp" Version="2.88.5" />
 		<PackageReference Include="SkiaSharp.Svg" Version="1.60.0" />

--- a/NuGet/IronSoftware.Drawing.nuspec
+++ b/NuGet/IronSoftware.Drawing.nuspec
@@ -60,6 +60,12 @@ For general support and technical inquiries, please email us at: developers@iron
 				<dependency id="SixLabors.ImageSharp.Drawing" version="1.0.0" />
 				<dependency id="BitMiracle.LibTiff.NET" version="2.4.649" />
 				<dependency id="System.Memory" version="4.5.5" />
+			</group>
+			<group targetFramework="MonoAndroid10.0">
+				<dependency id="SixLabors.ImageSharp" version="2.1.5" />
+				<dependency id="SixLabors.ImageSharp.Drawing" version="1.0.0" />
+				<dependency id="BitMiracle.LibTiff.NET" version="2.4.649" />
+				<dependency id="System.Memory" version="4.5.5" />
 				<dependency id="Microsoft.Maui.Graphics" version="7.0.92" />
 				<dependency id="SkiaSharp" version="2.88.5" />
 				<dependency id="SkiaSharp.Svg" version="1.60.0" />

--- a/NuGet/IronSoftware.Drawing.nuspec
+++ b/NuGet/IronSoftware.Drawing.nuspec
@@ -60,6 +60,7 @@ For general support and technical inquiries, please email us at: developers@iron
 				<dependency id="SixLabors.ImageSharp.Drawing" version="1.0.0" />
 				<dependency id="BitMiracle.LibTiff.NET" version="2.4.649" />
 				<dependency id="System.Memory" version="4.5.5" />
+				<dependency id="Microsoft.Maui.Graphics" version="7.0.92" />
 				<dependency id="SkiaSharp" version="2.88.5" />
 				<dependency id="SkiaSharp.Svg" version="1.60.0" />
 			</group>

--- a/NuGet/IronSoftware.Drawing.nuspec
+++ b/NuGet/IronSoftware.Drawing.nuspec
@@ -60,6 +60,8 @@ For general support and technical inquiries, please email us at: developers@iron
 				<dependency id="SixLabors.ImageSharp.Drawing" version="1.0.0" />
 				<dependency id="BitMiracle.LibTiff.NET" version="2.4.649" />
 				<dependency id="System.Memory" version="4.5.5" />
+				<dependency id="SkiaSharp" version="2.88.5" />
+				<dependency id="SkiaSharp.Svg" version="1.60.0" />
 			</group>
 		</dependencies>
 	</metadata>


### PR DESCRIPTION
### Description
When build Xamarin application it will look into all dependency inside the DLL. This PR intend to fix that problem by adding all missing library into netstandard2.1 dependency.

Now NuGet package on Monandroid10.0 will include:
1. SkiaSharp
2. SkiaSharp.Svg
3. Microsoft.Maui.Graphics

### Type of change
Please select the relevant option by placing an 'x' inside the brackets, like this: [x].

- [ ] 🐛 Bug fix (non-breaking change which fixes an issue)
- [ ] ✨ New feature (non-breaking change which adds functionality)
- [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] 🏗️ Internal/structural update (non-breaking change that improves code quality, organization, or performance)
- [ ] 📚 This change requires a documentation update
- [ ] 🚀 DevOps build chain modification for release
- [ ] 🤖 DevOps build chain modification for CI
- [X] 📦 NuGet package

### How Has This Been Tested?
Testing by @michael-ironsoftware on Xamarin application.

### Checklist:
Please run through the checklist as much as possible and mark the items completed by placing an 'x' inside the brackets, like this: [x].

- [ ] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] I have successfully run all unit tests on Windows
- [ ] I have successfully run all unit tests on Linux
