### PR TITLE
DW-8 SixLabors ImageSharp drawing version

### DIFF
--- a/CI/azure-pipelines-build.yml
+++ b/CI/azure-pipelines-build.yml
@@ -73,6 +73,7 @@ stages:
       publishAssemblies: true
       buildConfiguration: $(Configuration)
       dependsOn: 'PrepareDrawingAssemblyVersion'
+      prepareAssemblyVersion: true
 ## Test Windows
 - template: stage_templates/run_tests_on_pool.yml
   parameters:

--- a/CI/job_templates/build_drawing_libraries.yml
+++ b/CI/job_templates/build_drawing_libraries.yml
@@ -2,23 +2,25 @@ parameters:
   publishAssemblies: false
   buildConfiguration: ''
   dependsOn: ''
+  prepareAssemblyVersion: false
 
 jobs:
   - job: BuildDrawingLibraries
     dependsOn: ${{ parameters.dependsOn }}
     steps:
-    - download: current
-      artifact: 'AssemblyVersionInfo'
-    - powershell: |
-        $AssemblyVersion = Get-Content "$(Pipeline.Workspace)\AssemblyVersionInfo\AssemblyVersion.txt"
-        if (![string]::IsNullOrEmpty($AssemblyVersion)) {
-          Write-Host "Using AssemblyVersion from previous job: $AssemblyVersion"
-          Write-Host "##vso[task.setvariable variable=finalAssemblyVersion]$AssemblyVersion"
-        } else {
-          Write-Host "AssemblyVersion is not set, using default: 1.0.0.0"
-          Write-Host "##vso[task.setvariable variable=finalAssemblyVersion]1.0.0.0"
-        }
-      displayName: 'Use or Set Assembly Version'
+    - ${{ if eq(parameters.prepareAssemblyVersion, true) }}:
+      - download: current
+        artifact: 'AssemblyVersionInfo'
+      - powershell: |
+          $AssemblyVersion = Get-Content "$(Pipeline.Workspace)\AssemblyVersionInfo\AssemblyVersion.txt"
+          if (![string]::IsNullOrEmpty($AssemblyVersion)) {
+            Write-Host "Using AssemblyVersion from previous job: $AssemblyVersion"
+            Write-Host "##vso[task.setvariable variable=finalAssemblyVersion]$AssemblyVersion"
+          } else {
+            Write-Host "AssemblyVersion is not set, using default: 1.0.0.0"
+            Write-Host "##vso[task.setvariable variable=finalAssemblyVersion]1.0.0.0"
+          }
+        displayName: 'Use or Set Assembly Version'
     # Checkout Repo
     - checkout: self
       displayName: Checkout IronSoftware.Drawing repository

--- a/CI/job_templates/build_drawing_libraries.yml
+++ b/CI/job_templates/build_drawing_libraries.yml
@@ -12,12 +12,18 @@ jobs:
       - download: current
         artifact: 'AssemblyVersionInfo'
     - powershell: |
-        $AssemblyVersion = Get-Content "$(Pipeline.Workspace)\AssemblyVersionInfo\AssemblyVersion.txt"
-        if (![string]::IsNullOrEmpty($AssemblyVersion)) {
-          Write-Host "Using AssemblyVersion from previous job: $AssemblyVersion"
-          Write-Host "##vso[task.setvariable variable=finalAssemblyVersion]$AssemblyVersion"
+        $assemblyVersionFilePath = "$(Pipeline.Workspace)\AssemblyVersionInfo\AssemblyVersion.txt"
+        if (Test-Path $assemblyVersionFilePath) {
+          $AssemblyVersion = Get-Content $assemblyVersionFilePath
+          if (![string]::IsNullOrEmpty($AssemblyVersion)) {
+            Write-Host "Using AssemblyVersion from previous job: $AssemblyVersion"
+            Write-Host "##vso[task.setvariable variable=finalAssemblyVersion]$AssemblyVersion"
+          } else {
+            Write-Host "AssemblyVersion is empty, using default: 1.0.0.0"
+            Write-Host "##vso[task.setvariable variable=finalAssemblyVersion]1.0.0.0"
+          }
         } else {
-          Write-Host "AssemblyVersion is not set, using default: 1.0.0.0"
+          Write-Host "AssemblyVersion.txt not found, using default: 1.0.0.0"
           Write-Host "##vso[task.setvariable variable=finalAssemblyVersion]1.0.0.0"
         }
       displayName: 'Use or Set Assembly Version'

--- a/CI/job_templates/build_drawing_libraries.yml
+++ b/CI/job_templates/build_drawing_libraries.yml
@@ -11,16 +11,16 @@ jobs:
     - ${{ if eq(parameters.prepareAssemblyVersion, true) }}:
       - download: current
         artifact: 'AssemblyVersionInfo'
-      - powershell: |
-          $AssemblyVersion = Get-Content "$(Pipeline.Workspace)\AssemblyVersionInfo\AssemblyVersion.txt"
-          if (![string]::IsNullOrEmpty($AssemblyVersion)) {
-            Write-Host "Using AssemblyVersion from previous job: $AssemblyVersion"
-            Write-Host "##vso[task.setvariable variable=finalAssemblyVersion]$AssemblyVersion"
-          } else {
-            Write-Host "AssemblyVersion is not set, using default: 1.0.0.0"
-            Write-Host "##vso[task.setvariable variable=finalAssemblyVersion]1.0.0.0"
-          }
-        displayName: 'Use or Set Assembly Version'
+    - powershell: |
+        $AssemblyVersion = Get-Content "$(Pipeline.Workspace)\AssemblyVersionInfo\AssemblyVersion.txt"
+        if (![string]::IsNullOrEmpty($AssemblyVersion)) {
+          Write-Host "Using AssemblyVersion from previous job: $AssemblyVersion"
+          Write-Host "##vso[task.setvariable variable=finalAssemblyVersion]$AssemblyVersion"
+        } else {
+          Write-Host "AssemblyVersion is not set, using default: 1.0.0.0"
+          Write-Host "##vso[task.setvariable variable=finalAssemblyVersion]1.0.0.0"
+        }
+      displayName: 'Use or Set Assembly Version'
     # Checkout Repo
     - checkout: self
       displayName: Checkout IronSoftware.Drawing repository

--- a/IronSoftware.Drawing/IronSoftware.Drawing.Common/IronSoftware.Drawing.Common.csproj
+++ b/IronSoftware.Drawing/IronSoftware.Drawing.Common/IronSoftware.Drawing.Common.csproj
@@ -35,13 +35,13 @@
 	<Choose>
 		<When Condition="'$(TargetFramework)' == 'net60'">
 			<ItemGroup>
-				<PackageReference Include="SixLabors.ImageSharp" Version="3.0.1" />
+				<PackageReference Include="SixLabors.ImageSharp" Version="3.0.2" />
 				<PackageReference Include="SixLabors.ImageSharp.Drawing" Version="2.0.0" />
 			</ItemGroup>
 		</When>
 		<Otherwise>
 			<ItemGroup>
-				<PackageReference Include="SixLabors.ImageSharp" Version="2.1.5" />
+				<PackageReference Include="SixLabors.ImageSharp" Version="2.1.6" />
 				<PackageReference Include="SixLabors.ImageSharp.Drawing" Version="1.0.0" />
 			</ItemGroup>
 		</Otherwise>

--- a/IronSoftware.Drawing/IronSoftware.Drawing.Common/IronSoftware.Drawing.Common.csproj
+++ b/IronSoftware.Drawing/IronSoftware.Drawing.Common/IronSoftware.Drawing.Common.csproj
@@ -36,11 +36,13 @@
 		<When Condition="'$(TargetFramework)' == 'net60'">
 			<ItemGroup>
 				<PackageReference Include="SixLabors.ImageSharp" Version="3.0.1" />
+				<PackageReference Include="SixLabors.ImageSharp.Drawing" Version="2.0.0" />
 			</ItemGroup>
 		</When>
 		<Otherwise>
 			<ItemGroup>
 				<PackageReference Include="SixLabors.ImageSharp" Version="2.1.5" />
+				<PackageReference Include="SixLabors.ImageSharp.Drawing" Version="1.0.0" />
 			</ItemGroup>
 		</Otherwise>
 	</Choose>

--- a/NuGet/IronSoftware.Drawing.nuspec
+++ b/NuGet/IronSoftware.Drawing.nuspec
@@ -44,25 +44,25 @@ For general support and technical inquiries, please email us at: developers@iron
 		<repository type="git" url="https://github.com/iron-software/IronSoftware.Drawing.Common" commit="$commit$" />
 		<dependencies>
 			<group targetFramework="netstandard2.0">
-				<dependency id="SixLabors.ImageSharp" version="2.1.5" />
+				<dependency id="SixLabors.ImageSharp" version="2.1.6" />
 				<dependency id="SixLabors.ImageSharp.Drawing" version="1.0.0" />
 				<dependency id="BitMiracle.LibTiff.NET" version="2.4.649" />
 				<dependency id="System.Memory" version="4.5.5" />
 			</group>
 			<group targetFramework="net60">
-				<dependency id="SixLabors.ImageSharp" version="3.0.1" />
+				<dependency id="SixLabors.ImageSharp" version="3.0.2" />
 				<dependency id="SixLabors.ImageSharp.Drawing" version="2.0.0" />
 				<dependency id="BitMiracle.LibTiff.NET" version="2.4.649" />
 				<dependency id="System.Memory" version="4.5.5" />
 			</group>
 			<group targetFramework="netstandard2.1">
-				<dependency id="SixLabors.ImageSharp" version="2.1.5" />
+				<dependency id="SixLabors.ImageSharp" version="2.1.6" />
 				<dependency id="SixLabors.ImageSharp.Drawing" version="1.0.0" />
 				<dependency id="BitMiracle.LibTiff.NET" version="2.4.649" />
 				<dependency id="System.Memory" version="4.5.5" />
 			</group>
 			<group targetFramework="MonoAndroid10.0">
-				<dependency id="SixLabors.ImageSharp" version="2.1.5" />
+				<dependency id="SixLabors.ImageSharp" version="2.1.6" />
 				<dependency id="SixLabors.ImageSharp.Drawing" version="1.0.0" />
 				<dependency id="BitMiracle.LibTiff.NET" version="2.4.649" />
 				<dependency id="System.Memory" version="4.5.5" />

--- a/NuGet/IronSoftware.Drawing.nuspec
+++ b/NuGet/IronSoftware.Drawing.nuspec
@@ -51,7 +51,7 @@ For general support and technical inquiries, please email us at: developers@iron
 			</group>
 			<group targetFramework="net60">
 				<dependency id="SixLabors.ImageSharp" version="3.0.1" />
-				<dependency id="SixLabors.ImageSharp.Drawing" version="1.0.0" />
+				<dependency id="SixLabors.ImageSharp.Drawing" version="2.0.0" />
 				<dependency id="BitMiracle.LibTiff.NET" version="2.4.649" />
 				<dependency id="System.Memory" version="4.5.5" />
 			</group>


### PR DESCRIPTION
### Description
Using SixLabors.ImageSharp.Drawing v2.0.0 to net6.0 framework. SixLabors.Fonts will be included too because its dependency of SixLabors.ImageSharp.Drawing.
This to prevent issue when upgrading SixLabors.ImageSharp.Drawing or SixLabors.Fonts on NET6.0 or later.

Now IronDrawing dependencies goes crazy.
<img width="301" alt="image" src="https://github.com/iron-software/IronSoftware.System.Drawing/assets/104610177/66b9fa1e-36a1-4c35-bd81-74f5f8812917">


Fixes [QR-8](https://ironsoftware.atlassian.net/browse/DW-8)

### Type of change
- [ ] 🐛 Bug fix (non-breaking change which fixes an issue)
- [ ] ✨ New feature (non-breaking change which adds functionality)
- [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] 🏗️ Internal/structural update (non-breaking change that improves code quality, organization, or performance)
- [ ] 📚 This change requires a documentation update
- [ ] 🚀 DevOps build chain modification for release
- [ ] 🤖 DevOps build chain modification for CI
- [X] :dependabot: Dependencies management

### How Has This Been Tested?
Create RC and tested on BarCode.

### Checklist:
Please run through the checklist as much as possible and mark the items completed by placing an 'x' inside the brackets, like this: [x].

- [X] My code follows the style guidelines of this project
- [X] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [X] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] I have successfully run all unit tests on Windows
- [ ] I have successfully run all unit tests on Linux
