### PR TITLE
Fixed vulnerable to CVE-2023-4863

### DIFF
--- a/IronSoftware.Drawing/IronSoftware.Drawing.Common.Tests/IronSoftware.Drawing.Common.Tests.csproj
+++ b/IronSoftware.Drawing/IronSoftware.Drawing.Common.Tests/IronSoftware.Drawing.Common.Tests.csproj
@@ -12,11 +12,10 @@
 	<ItemGroup>
 		<PackageReference Include="FluentAssertions" Version="6.10.0" />
 		<PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.5.0" />
-		<PackageReference Include="SixLabors.ImageSharp.Drawing" Version="1.0.0" />
 		<PackageReference Include="Microsoft.Maui.Graphics" Version="7.0.92" />
-		<PackageReference Include="SkiaSharp" Version="2.88.5" />
-		<PackageReference Include="SkiaSharp.NativeAssets.Linux" Version="2.88.5" />
-		<PackageReference Include="System.Drawing.Common" Version="5.0.3" />
+		<PackageReference Include="SkiaSharp" Version="2.88.6" />
+		<PackageReference Include="SkiaSharp.NativeAssets.Linux" Version="2.88.6" />
+		<PackageReference Include="System.Drawing.Common" Version="6.0.0" />
 		<PackageReference Include="xunit" Version="2.4.2" />
 		<PackageReference Include="xunit.runner.visualstudio" Version="2.4.5">
 			<IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>

--- a/IronSoftware.Drawing/IronSoftware.Drawing.Common.Tests/UnitTests/AnyBitmapFunctionality.cs
+++ b/IronSoftware.Drawing/IronSoftware.Drawing.Common.Tests/UnitTests/AnyBitmapFunctionality.cs
@@ -151,7 +151,7 @@ namespace IronSoftware.Drawing.Common.Tests.UnitTests
             CleanResultFile("result-png-loss.png");
         }
 
-        [IgnoreOnMacFact]
+        [IgnoreOnUnixFact]
         public void CastBitmap_to_AnyBitmap()
         {
             string imagePath = GetRelativeFilePath("van-gogh-starry-night-vincent-van-gogh.jpg");
@@ -164,7 +164,7 @@ namespace IronSoftware.Drawing.Common.Tests.UnitTests
             AssertImageAreEqual("expected.bmp", "result.bmp", true);
         }
 
-        [IgnoreOnMacFact]
+        [IgnoreOnUnixFact]
         public void CastBitmap_from_AnyBitmap()
         {
             var anyBitmap = AnyBitmap.FromFile(GetRelativeFilePath("van-gogh-starry-night-vincent-van-gogh.jpg"));
@@ -176,7 +176,7 @@ namespace IronSoftware.Drawing.Common.Tests.UnitTests
             AssertImageAreEqual("expected.bmp", "result.bmp", true);
         }
 
-        [IgnoreOnMacFact]
+        [IgnoreOnUnixFact]
         public void CastImage_to_AnyBitmap()
         {
             string imagePath = GetRelativeFilePath("van-gogh-starry-night-vincent-van-gogh.jpg");
@@ -189,7 +189,7 @@ namespace IronSoftware.Drawing.Common.Tests.UnitTests
             AssertImageAreEqual("expected.bmp", "result.bmp", true);
         }
 
-        [IgnoreOnMacFact]
+        [IgnoreOnUnixFact]
         public void CastImage_from_AnyBitmap()
         {
             var anyBitmap = AnyBitmap.FromFile(GetRelativeFilePath("van-gogh-starry-night-vincent-van-gogh.jpg"));
@@ -576,7 +576,7 @@ namespace IronSoftware.Drawing.Common.Tests.UnitTests
             Assert.NotEqual(IntPtr.Zero, bitmap.Scan0);
         }
 
-        [IgnoreOnMacFact]
+        [IgnoreOnUnixFact]
         public void Should_Return_Stride()
         {
             string imagePath = GetRelativeFilePath("van-gogh-starry-night-vincent-van-gogh.jpg");

--- a/IronSoftware.Drawing/IronSoftware.Drawing.Common.Tests/UnitTests/FontFunctionality.cs
+++ b/IronSoftware.Drawing/IronSoftware.Drawing.Common.Tests/UnitTests/FontFunctionality.cs
@@ -136,7 +136,7 @@ namespace IronSoftware.Drawing.Common.Tests.UnitTests
             }
         }
 
-        [IgnoreOnMacFact]
+        [IgnoreOnUnixFact]
         public void CastSystemDrawingFont_to_Font()
         {
             if (RuntimeInformation.IsOSPlatform(OSPlatform.Linux))
@@ -177,7 +177,7 @@ namespace IronSoftware.Drawing.Common.Tests.UnitTests
             }
         }
 
-        [IgnoreOnMacFact]
+        [IgnoreOnUnixFact]
         public void CastSystemDrawingFont_from_Font()
         {
             if (RuntimeInformation.IsOSPlatform(OSPlatform.Linux))

--- a/IronSoftware.Drawing/IronSoftware.Drawing.Common.Tests/XUnitAttributes/IgnoreOnUnixFactAttribute.cs
+++ b/IronSoftware.Drawing/IronSoftware.Drawing.Common.Tests/XUnitAttributes/IgnoreOnUnixFactAttribute.cs
@@ -1,6 +1,6 @@
 ﻿using System;
 using System.Runtime.CompilerServices;
-using Xunit;
+using System.Runtime.InteropServices;
 
 namespace IronSoftware.Drawing.Common.Tests.UnitTests
 {
@@ -18,14 +18,14 @@ namespace IronSoftware.Drawing.Common.Tests.UnitTests
                 return;
             }
 
-            Skip = "Ignored on Azure DevOps";
+            Skip = "Ignored on Azure Linux or OSX";
         }
 
-        /// <summary>Determine if runtime is Azure DevOps.</summary>
-        /// <returns>True if being executed in Azure DevOps, false otherwise.</returns>
+        /// <summary>Determine if runtime is Linux or OSX.</summary>
+        /// <returns>True if being executed in Linux or OSX, false otherwise.</returns>
         public static bool IsRunningOnUnix()
         {
-            return Environment.OSVersion.Platform == PlatformID.Unix;
+            return Environment.OSVersion.Platform == PlatformID.Unix || RuntimeInformation.IsOSPlatform(OSPlatform.OSX);
         }
     }
 }

--- a/IronSoftware.Drawing/IronSoftware.Drawing.Common/IronSoftware.Drawing.Common.csproj
+++ b/IronSoftware.Drawing/IronSoftware.Drawing.Common/IronSoftware.Drawing.Common.csproj
@@ -24,10 +24,9 @@
 	<ItemGroup>
 		<PackageReference Include="BitMiracle.LibTiff.NET" Version="2.4.649" />
 		<PackageReference Include="Microsoft.Maui.Graphics" Version="7.0.92" />
-		<PackageReference Include="SixLabors.ImageSharp.Drawing" Version="1.0.0" />
-		<PackageReference Include="SkiaSharp" Version="2.88.5" />
+		<PackageReference Include="SkiaSharp" Version="2.88.6" />
 		<PackageReference Include="SkiaSharp.Svg" Version="1.60.0" />
-		<PackageReference Include="System.Drawing.Common" Version="5.0.3" />
+		<PackageReference Include="System.Drawing.Common" Version="6.0.0" />
 		<PackageReference Include="System.Memory" Version="4.5.5" />
 		<PackageReference Include="Microsoft.SourceLink.GitHub" Version="1.1.1" PrivateAssets="All" />
 	</ItemGroup>

--- a/NuGet/IronSoftware.Drawing.nuspec
+++ b/NuGet/IronSoftware.Drawing.nuspec
@@ -67,7 +67,7 @@ For general support and technical inquiries, please email us at: developers@iron
 				<dependency id="BitMiracle.LibTiff.NET" version="2.4.649" />
 				<dependency id="System.Memory" version="4.5.5" />
 				<dependency id="Microsoft.Maui.Graphics" version="7.0.92" />
-				<dependency id="SkiaSharp" version="2.88.5" />
+				<dependency id="SkiaSharp" version="2.88.6" />
 				<dependency id="SkiaSharp.Svg" version="1.60.0" />
 			</group>
 		</dependencies>


### PR DESCRIPTION
### Description
Update SkiaSharp to v2.88.6 which fixed vulnerable to CVE-2023-4863

### Type of change
Please select the relevant option by placing an 'x' inside the brackets, like this: [x].

- [X] 🐛 Bug fix (non-breaking change which fixes an issue)
- [ ] ✨ New feature (non-breaking change which adds functionality)
- [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] 🏗️ Internal/structural update (non-breaking change that improves code quality, organization, or performance)
- [ ] 📚 This change requires a documentation update
- [ ] 🚀 DevOps build chain modification for release
- [ ] 🤖 DevOps build chain modification for CI
