### PR TITLE
Color: Add empty constructor with XML comment

### DIFF
--- a/IronSoftware.Drawing/IronSoftware.Drawing.Common.Tests/UnitTests/ColorFunctionality.cs
+++ b/IronSoftware.Drawing/IronSoftware.Drawing.Common.Tests/UnitTests/ColorFunctionality.cs
@@ -629,6 +629,17 @@ namespace IronSoftware.Drawing.Common.Tests.UnitTests
             Assert.Equal(expectedBrightness, brightness, 5);
         }
 
+        [FactWithAutomaticDisplayName]
+        public void TestEmptyConstructor()
+        {
+            var color = new Color();
+
+            color.A.Should().Be(0);
+            color.R.Should().Be(0);
+            color.G.Should().Be(0);
+            color.B.Should().Be(0);
+        }
+
 #if !NETFRAMEWORK
         [FactWithAutomaticDisplayName]
         public void Cast_Maui_from_Color()

--- a/IronSoftware.Drawing/IronSoftware.Drawing.Common/Color.cs
+++ b/IronSoftware.Drawing/IronSoftware.Drawing.Common/Color.cs
@@ -104,6 +104,20 @@ namespace IronSoftware.Drawing
         }
 
         /// <summary>
+        /// Initializes a new instance of the <see cref="Color"/> class with default values.
+        /// </summary>
+        /// <remarks>
+        /// The default color is fully transparent black, with an ARGB value of (0, 0, 0, 0).
+        /// </remarks>
+        public Color()
+        {
+            A = 0;
+            R = 0;
+            G = 0;
+            B = 0;
+        }
+
+        /// <summary>
         /// Represents a color that is null.
         /// </summary>
         public static readonly Color Empty;

--- a/README.md
+++ b/README.md
@@ -6,14 +6,16 @@
 
 ## Table of Contents
 
-- [Features](#ironsoftwaredrawing-features)
-  - [Compatibility](#ironsoftwaredrawing-has-cross-platform-support-compatibility-with)
-- [Using IronSoftware.Drawing](#using-ironsoftwaredrawing)
-  - [AnyBitmap Example](#anybitmap-code-example)
-  - [Color Example](#color-code-example)
-  - [Rectangle Example](#croprectangle-code-example)
-  - [Font Example](#font-code-example)
-- [Support](#support-available)
+- [IronSoftware.Drawing - Image, Color, Rectangle, and Font class for .NET Applications](#ironsoftwaredrawing---image-color-rectangle-and-font-class-for-net-applications)
+  - [Table of Contents](#table-of-contents)
+  - [IronSoftware.Drawing Features:](#ironsoftwaredrawing-features)
+    - [IronSoftware.Drawing has cross platform support compatibility with:](#ironsoftwaredrawing-has-cross-platform-support-compatibility-with)
+  - [Using IronSoftware.Drawing](#using-ironsoftwaredrawing)
+    - [`AnyBitmap` Code Example](#anybitmap-code-example)
+    - [`Color` Code Example](#color-code-example)
+    - [`Rectangle` Code Example](#rectangle-code-example)
+    - [`Font` Code Example](#font-code-example)
+  - [Support Available](#support-available)
 
 ## IronSoftware.Drawing Features:
 - **AnyBitmap**: A universally compatible Bitmap class. Implicit casting between `IronSoftware.Drawing.AnyBitmap` and following popular Bitmap/Image formats supported:
@@ -125,6 +127,7 @@ using IronSoftware.Drawing;
 Color fromHex = new Color("#191919");
 Color fromRgb = new Color(255, 255, 0);
 Color fromEnum = Color.Crimson;
+Color transparentBlack = new Color();
 
 // Casting between System.Drawing.Color and IronSoftware.Drawing.Color
 System.Drawing.Color drawingColor = System.Drawing.Color.Red;


### PR DESCRIPTION
### Description
This Pull request introduces a new empty constructor for the `Color` class along with an accompanying XML comment. The constructor initializes a new instance of the `Color` class with default color is fully transparent black.

To use in IronWord.

### Type of change
Please select the relevant option by placing an 'x' inside the brackets, like this: [x].
- [ ] 🐛 Bug fix (non-breaking change which fixes an issue)
- [X] ✨ New feature (non-breaking change which adds functionality)
- [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] 🏗️ Internal/structural update (non-breaking change that improves code quality, organization, or performance)
- [X] 📚 This change requires a documentation update
- [ ] 🚀 DevOps build chain modification for release
- [ ] 🤖 DevOps build chain modification for CI

### How Has This Been Tested?
Add test for it.

### Checklist:
Please run through the checklist as much as possible and mark the items completed by placing an 'x' inside the brackets, like this: [x].

- [X] My code follows the style guidelines of this project
- [X] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [X] I have made corresponding changes to the documentation
- [X] My changes generate no new warnings
- [X] I have added tests that prove my fix is effective or that my feature works
- [X] New and existing unit tests pass locally with my changes
