### PR TITLE
Add Size & SizeF structs

### DIFF
--- a/IronSoftware.Drawing/IronSoftware.Drawing.Common.Tests/UnitTests/SizeFFunctionality.cs
+++ b/IronSoftware.Drawing/IronSoftware.Drawing.Common.Tests/UnitTests/SizeFFunctionality.cs
@@ -1,0 +1,240 @@
+﻿using System;
+using System.Globalization;
+using Xunit;
+using Xunit.Abstractions;
+
+namespace IronSoftware.Drawing.Common.Tests.UnitTests;
+
+public class SizeFFunctionality : TestsBase
+{
+    public SizeFFunctionality(ITestOutputHelper output) 
+        : base(output) { }
+
+    [Fact]
+    public void DefaultConstructorTest()
+    {
+        Assert.Equal(default, SizeF.Empty);
+    }
+
+    [Theory]
+    [InlineData(float.MaxValue, float.MinValue)]
+    [InlineData(float.MinValue, float.MinValue)]
+    [InlineData(float.MaxValue, float.MaxValue)]
+    [InlineData(0, 0)]
+    public void NonDefaultConstructorAndDimensionsTest(float width, float height)
+    {
+        var s1 = new SizeF(width, height);
+        var p1 = new PointF(width, height);
+        var s2 = new SizeF(s1);
+
+        Assert.Equal(s1, s2);
+        Assert.Equal(s1, new SizeF(p1));
+        Assert.Equal(s2, new SizeF(p1));
+
+        Assert.Equal(width, s1.Width);
+        Assert.Equal(height, s1.Height);
+
+        s1.Width = 10;
+        Assert.Equal(10, s1.Width);
+
+        s1.Height = -10.123f;
+        Assert.Equal(-10.123, s1.Height, 3);
+    }
+
+    [Fact]
+    public void IsEmptyDefaultsTest()
+    {
+        Assert.True(SizeF.Empty.IsEmpty);
+        Assert.True(default(SizeF).IsEmpty);
+        Assert.True(new SizeF(0, 0).IsEmpty);
+    }
+
+    [Theory]
+    [InlineData(float.MaxValue, float.MinValue)]
+    [InlineData(float.MinValue, float.MinValue)]
+    [InlineData(float.MaxValue, float.MaxValue)]
+    public void IsEmptyRandomTest(float width, float height)
+    {
+        Assert.False(new SizeF(width, height).IsEmpty);
+    }
+
+    [Theory]
+    [InlineData(float.MaxValue, float.MinValue)]
+    [InlineData(float.MinValue, float.MinValue)]
+    [InlineData(float.MaxValue, float.MaxValue)]
+    [InlineData(0, 0)]
+    public void ArithmeticTest(float width, float height)
+    {
+        var s1 = new SizeF(width, height);
+        var s2 = new SizeF(height, width);
+        var addExpected = new SizeF(width + height, width + height);
+        var subExpected = new SizeF(width - height, height - width);
+
+        Assert.Equal(addExpected, s1 + s2);
+        Assert.Equal(addExpected, SizeF.Add(s1, s2));
+
+        Assert.Equal(subExpected, s1 - s2);
+        Assert.Equal(subExpected, SizeF.Subtract(s1, s2));
+    }
+
+    [Theory]
+    [InlineData(float.MaxValue, float.MinValue)]
+    [InlineData(float.MinValue, float.MinValue)]
+    [InlineData(float.MaxValue, float.MaxValue)]
+    [InlineData(0, 0)]
+    public void EqualityTest(float width, float height)
+    {
+        var sLeft = new SizeF(width, height);
+        var sRight = new SizeF(height, width);
+
+        if (width == height)
+        {
+            Assert.True(sLeft == sRight);
+            Assert.False(sLeft != sRight);
+            Assert.True(sLeft.Equals(sRight));
+            Assert.True(sLeft.Equals((object)sRight));
+            Assert.Equal(sLeft.GetHashCode(), sRight.GetHashCode());
+            return;
+        }
+
+        Assert.True(sLeft != sRight);
+        Assert.False(sLeft == sRight);
+        Assert.False(sLeft.Equals(sRight));
+        Assert.False(sLeft.Equals((object)sRight));
+    }
+
+    [Fact]
+    public void EqualityTest_NotSizeF()
+    {
+        var size = new SizeF(0, 0);
+        Assert.False(size.Equals(null));
+        Assert.False(size.Equals(0));
+
+        // If SizeF implements IEquatable<SizeF> (e.g in .NET Core), then classes that are implicitly
+        // convertible to SizeF can potentially be equal.
+        // See https://github.com/dotnet/corefx/issues/5255.
+        bool expectsImplicitCastToSizeF = typeof(IEquatable<SizeF>).IsAssignableFrom(size.GetType());
+        Assert.Equal(expectsImplicitCastToSizeF, size.Equals(new Size(0, 0)));
+
+        Assert.False(size.Equals((object)new Size(0, 0))); // No implicit cast
+    }
+
+    [Theory]
+    [InlineData(float.MaxValue, float.MinValue)]
+    [InlineData(float.MinValue, float.MinValue)]
+    [InlineData(float.MaxValue, float.MaxValue)]
+    [InlineData(0, 0)]
+    public void ConversionTest(float width, float height)
+    {
+        var s1 = new SizeF(width, height);
+        var p1 = (PointF)s1;
+        var s2 = new Size(unchecked((int)width), unchecked((int)height));
+
+        Assert.Equal(new PointF(width, height), p1);
+        Assert.Equal(p1, (PointF)s1);
+        Assert.Equal(s2, (Size)s1);
+    }
+
+    [Fact]
+    public void ToStringTest()
+    {
+        var sz = new SizeF(10, 5);
+        Assert.Equal(string.Format(CultureInfo.CurrentCulture, "SizeF [ Width={0}, Height={1} ]", sz.Width, sz.Height), sz.ToString());
+    }
+
+    [Theory]
+    [InlineData(1000.234f, 0.0f)]
+    [InlineData(1000.234f, 1.0f)]
+    [InlineData(1000.234f, 2400.933f)]
+    [InlineData(1000.234f, float.MaxValue)]
+    [InlineData(1000.234f, -1.0f)]
+    [InlineData(1000.234f, -2400.933f)]
+    [InlineData(1000.234f, float.MinValue)]
+    [InlineData(float.MaxValue, 0.0f)]
+    [InlineData(float.MaxValue, 1.0f)]
+    [InlineData(float.MaxValue, 2400.933f)]
+    [InlineData(float.MaxValue, float.MaxValue)]
+    [InlineData(float.MaxValue, -1.0f)]
+    [InlineData(float.MaxValue, -2400.933f)]
+    [InlineData(float.MaxValue, float.MinValue)]
+    [InlineData(float.MinValue, 0.0f)]
+    [InlineData(float.MinValue, 1.0f)]
+    [InlineData(float.MinValue, 2400.933f)]
+    [InlineData(float.MinValue, float.MaxValue)]
+    [InlineData(float.MinValue, -1.0f)]
+    [InlineData(float.MinValue, -2400.933f)]
+    [InlineData(float.MinValue, float.MinValue)]
+    public void MultiplicationTest(float dimension, float multiplier)
+    {
+        SizeF sz1 = new SizeF(dimension, dimension);
+        SizeF mulExpected;
+
+        mulExpected = new SizeF(dimension * multiplier, dimension * multiplier);
+
+        Assert.Equal(mulExpected, sz1 * multiplier);
+        Assert.Equal(mulExpected, multiplier * sz1);
+    }
+
+    [Theory]
+    [InlineData(1111.1111f, 2222.2222f, 3333.3333f)]
+    public void MultiplicationTestWidthHeightMultiplier(float width, float height, float multiplier)
+    {
+        SizeF sz1 = new SizeF(width, height);
+        SizeF mulExpected;
+
+        mulExpected = new SizeF(width * multiplier, height * multiplier);
+
+        Assert.Equal(mulExpected, sz1 * multiplier);
+        Assert.Equal(mulExpected, multiplier * sz1);
+    }
+
+    [Theory]
+    [InlineData(0.0f, 1.0f)]
+    [InlineData(1.0f, 1.0f)]
+    [InlineData(-1.0f, 1.0f)]
+    [InlineData(1.0f, -1.0f)]
+    [InlineData(-1.0f, -1.0f)]
+    [InlineData(float.MaxValue, float.MaxValue)]
+    [InlineData(float.MaxValue, float.MinValue)]
+    [InlineData(float.MinValue, float.MaxValue)]
+    [InlineData(float.MinValue, float.MinValue)]
+    [InlineData(float.MaxValue, 1.0f)]
+    [InlineData(float.MinValue, 1.0f)]
+    [InlineData(float.MaxValue, -1.0f)]
+    [InlineData(float.MinValue, -1.0f)]
+    [InlineData(float.MinValue, 0.0f)]
+    [InlineData(1.0f, float.MinValue)]
+    [InlineData(1.0f, float.MaxValue)]
+    [InlineData(-1.0f, float.MinValue)]
+    [InlineData(-1.0f, float.MaxValue)]
+    public void DivideTestSizeFloat(float dimension, float divisor)
+    {
+        SizeF size = new SizeF(dimension, dimension);
+        SizeF expected = new SizeF(dimension / divisor, dimension / divisor);
+        Assert.Equal(expected, size / divisor);
+    }
+
+    [Theory]
+    [InlineData(-111.111f, 222.222f, 333.333f)]
+    public void DivideTestSizeFloatWidthHeightDivisor(float width, float height, float divisor)
+    {
+        SizeF size = new SizeF(width, height);
+        SizeF expected = new SizeF(width / divisor, height / divisor);
+        Assert.Equal(expected, size / divisor);
+    }
+
+    [Theory]
+    [InlineData(float.MaxValue, float.MinValue)]
+    [InlineData(float.MinValue, float.MinValue)]
+    [InlineData(float.MaxValue, float.MaxValue)]
+    [InlineData(0, 0)]
+    public void DeconstructTest(float width, float height)
+    {
+        SizeF s = new SizeF(width, height);
+
+        (float deconstructedWidth, float deconstructedHeight) = s;
+
+        Assert.Equal(width, deconstructedWidth);
+        Assert.Equal(height, deconstructedHeight);
+    }
+}

--- a/IronSoftware.Drawing/IronSoftware.Drawing.Common.Tests/UnitTests/SizeFunctionality.cs
+++ b/IronSoftware.Drawing/IronSoftware.Drawing.Common.Tests/UnitTests/SizeFunctionality.cs
@@ -1,0 +1,345 @@
+﻿using System.Globalization;
+using System;
+using Xunit;
+using Xunit.Abstractions;
+
+namespace IronSoftware.Drawing.Common.Tests.UnitTests;
+
+public class SizeFunctionality : TestsBase
+{
+    public SizeFunctionality(ITestOutputHelper output)
+        : base(output) { }
+
+    [Fact]
+    public void DefaultConstructorTest()
+    {
+        Assert.Equal(default, Size.Empty);
+    }
+
+    [Theory]
+    [InlineData(int.MaxValue, int.MinValue)]
+    [InlineData(int.MinValue, int.MinValue)]
+    [InlineData(int.MaxValue, int.MaxValue)]
+    [InlineData(0, 0)]
+    public void NonDefaultConstructorTest(int width, int height)
+    {
+        var s1 = new Size(width, height);
+        var s2 = new Size(new Point(width, height));
+
+        Assert.Equal(s1, s2);
+
+        s1.Width = 10;
+        Assert.Equal(10, s1.Width);
+
+        s1.Height = -10;
+        Assert.Equal(-10, s1.Height);
+    }
+
+    [Fact]
+    public void IsEmptyDefaultsTest()
+    {
+        Assert.True(Size.Empty.IsEmpty);
+        Assert.True(default(Size).IsEmpty);
+        Assert.True(new Size(0, 0).IsEmpty);
+    }
+
+    [Theory]
+    [InlineData(int.MaxValue, int.MinValue)]
+    [InlineData(int.MinValue, int.MinValue)]
+    [InlineData(int.MaxValue, int.MaxValue)]
+    public void IsEmptyRandomTest(int width, int height)
+    {
+        Assert.False(new Size(width, height).IsEmpty);
+    }
+
+    [Theory]
+    [InlineData(int.MaxValue, int.MinValue)]
+    [InlineData(int.MinValue, int.MinValue)]
+    [InlineData(int.MaxValue, int.MaxValue)]
+    [InlineData(0, 0)]
+    public void DimensionsTest(int width, int height)
+    {
+        var p = new Size(width, height);
+        Assert.Equal(width, p.Width);
+        Assert.Equal(height, p.Height);
+    }
+
+    [Theory]
+    [InlineData(int.MaxValue, int.MinValue)]
+    [InlineData(int.MinValue, int.MinValue)]
+    [InlineData(int.MaxValue, int.MaxValue)]
+    [InlineData(0, 0)]
+    public void PointFConversionTest(int width, int height)
+    {
+        SizeF sz = new Size(width, height);
+        Assert.Equal(new SizeF(width, height), sz);
+    }
+
+    [Theory]
+    [InlineData(int.MaxValue, int.MinValue)]
+    [InlineData(int.MinValue, int.MinValue)]
+    [InlineData(int.MaxValue, int.MaxValue)]
+    [InlineData(0, 0)]
+    public void SizeConversionTest(int width, int height)
+    {
+        var sz = (Point)new Size(width, height);
+        Assert.Equal(new Point(width, height), sz);
+    }
+
+    [Theory]
+    [InlineData(int.MaxValue, int.MinValue)]
+    [InlineData(int.MinValue, int.MinValue)]
+    [InlineData(int.MaxValue, int.MaxValue)]
+    [InlineData(0, 0)]
+    public void ArithmeticTest(int width, int height)
+    {
+        var sz1 = new Size(width, height);
+        var sz2 = new Size(height, width);
+        Size addExpected, subExpected;
+
+        unchecked
+        {
+            addExpected = new Size(width + height, height + width);
+            subExpected = new Size(width - height, height - width);
+        }
+
+        Assert.Equal(addExpected, sz1 + sz2);
+        Assert.Equal(subExpected, sz1 - sz2);
+        Assert.Equal(addExpected, Size.Add(sz1, sz2));
+        Assert.Equal(subExpected, Size.Subtract(sz1, sz2));
+    }
+
+    [Theory]
+    [InlineData(int.MaxValue, int.MinValue)]
+    [InlineData(int.MinValue, int.MinValue)]
+    [InlineData(int.MaxValue, int.MaxValue)]
+    [InlineData(0, 0)]
+    public void EqualityTest(int width, int height)
+    {
+        var p1 = new Size(width, height);
+        var p2 = new Size(unchecked(width - 1), unchecked(height - 1));
+        var p3 = new Size(width, height);
+
+        Assert.True(p1 == p3);
+        Assert.True(p1 != p2);
+        Assert.True(p2 != p3);
+
+        Assert.True(p1.Equals(p3));
+        Assert.False(p1.Equals(p2));
+        Assert.False(p2.Equals(p3));
+
+        Assert.True(p1.Equals((object)p3));
+        Assert.False(p1.Equals((object)p2));
+        Assert.False(p2.Equals((object)p3));
+
+        Assert.Equal(p1.GetHashCode(), p3.GetHashCode());
+    }
+
+    [Fact]
+    public void EqualityTest_NotSize()
+    {
+        var size = new Size(0, 0);
+        Assert.False(size.Equals(null));
+        Assert.False(size.Equals(0));
+        Assert.False(size.Equals(new SizeF(0, 0)));
+    }
+
+    [Fact]
+    public void ToStringTest()
+    {
+        var sz = new Size(10, 5);
+        Assert.Equal(string.Format(CultureInfo.CurrentCulture, "Size [ Width={0}, Height={1} ]", sz.Width, sz.Height), sz.ToString());
+    }
+
+    [Theory]
+    [InlineData(1000, 0)]
+    [InlineData(1000, 1)]
+    [InlineData(1000, 2400)]
+    [InlineData(1000, int.MaxValue)]
+    [InlineData(1000, -1)]
+    [InlineData(1000, -2400)]
+    [InlineData(1000, int.MinValue)]
+    [InlineData(int.MaxValue, 0)]
+    [InlineData(int.MaxValue, 1)]
+    [InlineData(int.MaxValue, 2400)]
+    [InlineData(int.MaxValue, int.MaxValue)]
+    [InlineData(int.MaxValue, -1)]
+    [InlineData(int.MaxValue, -2400)]
+    [InlineData(int.MaxValue, int.MinValue)]
+    [InlineData(int.MinValue, 0)]
+    [InlineData(int.MinValue, 1)]
+    [InlineData(int.MinValue, 2400)]
+    [InlineData(int.MinValue, int.MaxValue)]
+    [InlineData(int.MinValue, -1)]
+    [InlineData(int.MinValue, -2400)]
+    [InlineData(int.MinValue, int.MinValue)]
+    public void MultiplicationTestSizeInt(int dimension, int multiplier)
+    {
+        Size sz1 = new Size(dimension, dimension);
+        Size mulExpected;
+
+        unchecked
+        {
+            mulExpected = new Size(dimension * multiplier, dimension * multiplier);
+        }
+
+        Assert.Equal(mulExpected, sz1 * multiplier);
+        Assert.Equal(mulExpected, multiplier * sz1);
+    }
+
+    [Theory]
+    [InlineData(1000, 2000, 3000)]
+    public void MultiplicationTestSizeIntWidthHeightMultiplier(int width, int height, int multiplier)
+    {
+        Size sz1 = new Size(width, height);
+        Size mulExpected;
+
+        unchecked
+        {
+            mulExpected = new Size(width * multiplier, height * multiplier);
+        }
+
+        Assert.Equal(mulExpected, sz1 * multiplier);
+        Assert.Equal(mulExpected, multiplier * sz1);
+    }
+
+    [Theory]
+    [InlineData(1000, 0.0f)]
+    [InlineData(1000, 1.0f)]
+    [InlineData(1000, 2400.933f)]
+    [InlineData(1000, float.MaxValue)]
+    [InlineData(1000, -1.0f)]
+    [InlineData(1000, -2400.933f)]
+    [InlineData(1000, float.MinValue)]
+    [InlineData(int.MaxValue, 0.0f)]
+    [InlineData(int.MaxValue, 1.0f)]
+    [InlineData(int.MaxValue, 2400.933f)]
+    [InlineData(int.MaxValue, float.MaxValue)]
+    [InlineData(int.MaxValue, -1.0f)]
+    [InlineData(int.MaxValue, -2400.933f)]
+    [InlineData(int.MaxValue, float.MinValue)]
+    [InlineData(int.MinValue, 0.0f)]
+    [InlineData(int.MinValue, 1.0f)]
+    [InlineData(int.MinValue, 2400.933f)]
+    [InlineData(int.MinValue, float.MaxValue)]
+    [InlineData(int.MinValue, -1.0f)]
+    [InlineData(int.MinValue, -2400.933f)]
+    [InlineData(int.MinValue, float.MinValue)]
+    public void MultiplicationTestSizeFloat(int dimension, float multiplier)
+    {
+        Size sz1 = new Size(dimension, dimension);
+        SizeF mulExpected;
+
+        mulExpected = new SizeF(dimension * multiplier, dimension * multiplier);
+
+        Assert.Equal(mulExpected, sz1 * multiplier);
+        Assert.Equal(mulExpected, multiplier * sz1);
+    }
+
+    [Theory]
+    [InlineData(1000, 2000, 30.33f)]
+    public void MultiplicationTestSizeFloatWidthHeightMultiplier(int width, int height, float multiplier)
+    {
+        Size sz1 = new Size(width, height);
+        SizeF mulExpected;
+
+        mulExpected = new SizeF(width * multiplier, height * multiplier);
+
+        Assert.Equal(mulExpected, sz1 * multiplier);
+        Assert.Equal(mulExpected, multiplier * sz1);
+    }
+
+    [Fact]
+    public void DivideByZeroChecks()
+    {
+        Size size = new Size(100, 100);
+        Assert.Throws<DivideByZeroException>(() => size / 0);
+
+        SizeF expectedSizeF = new SizeF(float.PositiveInfinity, float.PositiveInfinity);
+        Assert.Equal(expectedSizeF, size / 0.0f);
+    }
+
+    [Theory]
+    [InlineData(0, 1)]
+    [InlineData(1, 1)]
+    [InlineData(-1, 1)]
+    [InlineData(1, -1)]
+    [InlineData(-1, -1)]
+    [InlineData(int.MaxValue, int.MaxValue)]
+    [InlineData(int.MaxValue, int.MinValue)]
+    [InlineData(int.MinValue, int.MaxValue)]
+    [InlineData(int.MinValue, int.MinValue)]
+    [InlineData(int.MaxValue, 1)]
+    [InlineData(int.MinValue, 1)]
+    [InlineData(int.MaxValue, -1)]
+    public void DivideTestSizeInt(int dimension, int divisor)
+    {
+        Size size = new Size(dimension, dimension);
+        Size expected;
+
+        expected = new Size(dimension / divisor, dimension / divisor);
+
+        Assert.Equal(expected, size / divisor);
+    }
+
+    [Theory]
+    [InlineData(1111, 2222, 3333)]
+    public void DivideTestSizeIntWidthHeightDivisor(int width, int height, int divisor)
+    {
+        Size size = new Size(width, height);
+        Size expected;
+
+        expected = new Size(width / divisor, height / divisor);
+
+        Assert.Equal(expected, size / divisor);
+    }
+
+    [Theory]
+    [InlineData(0, 1.0f)]
+    [InlineData(1, 1.0f)]
+    [InlineData(-1, 1.0f)]
+    [InlineData(1, -1.0f)]
+    [InlineData(-1, -1.0f)]
+    [InlineData(int.MaxValue, float.MaxValue)]
+    [InlineData(int.MaxValue, float.MinValue)]
+    [InlineData(int.MinValue, float.MaxValue)]
+    [InlineData(int.MinValue, float.MinValue)]
+    [InlineData(int.MaxValue, 1.0f)]
+    [InlineData(int.MinValue, 1.0f)]
+    [InlineData(int.MaxValue, -1.0f)]
+    [InlineData(int.MinValue, -1.0f)]
+    public void DivideTestSizeFloat(int dimension, float divisor)
+    {
+        SizeF size = new SizeF(dimension, dimension);
+        SizeF expected;
+
+        expected = new SizeF(dimension / divisor, dimension / divisor);
+        Assert.Equal(expected, size / divisor);
+    }
+
+    [Theory]
+    [InlineData(1111, 2222, -333.33f)]
+    public void DivideTestSizeFloatWidthHeightDivisor(int width, int height, float divisor)
+    {
+        SizeF size = new SizeF(width, height);
+        SizeF expected;
+
+        expected = new SizeF(width / divisor, height / divisor);
+        Assert.Equal(expected, size / divisor);
+    }
+
+    [Theory]
+    [InlineData(int.MaxValue, int.MinValue)]
+    [InlineData(int.MinValue, int.MinValue)]
+    [InlineData(int.MaxValue, int.MaxValue)]
+    [InlineData(0, 0)]
+    public void DeconstructTest(int width, int height)
+    {
+        Size s = new Size(width, height);
+
+        (int deconstructedWidth, int deconstructedHeight) = s;
+
+        Assert.Equal(width, deconstructedWidth);
+        Assert.Equal(height, deconstructedHeight);
+    }
+}

--- a/IronSoftware.Drawing/IronSoftware.Drawing.Common/Rectangle.cs
+++ b/IronSoftware.Drawing/IronSoftware.Drawing.Common/Rectangle.cs
@@ -1,4 +1,6 @@
 ﻿using System;
+using System.ComponentModel;
+using System.Runtime.CompilerServices;
 
 namespace IronSoftware.Drawing
 {
@@ -30,6 +32,26 @@ namespace IronSoftware.Drawing
             Y = y;
             Width = width;
             Height = height;
+            Units = units;
+        }
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="Rectangle"/> struct.
+        /// </summary>
+        /// <param name="point">
+        /// The <see cref="Point"/> which specifies the rectangles point in a two-dimensional plane.
+        /// </param>
+        /// <param name="size">
+        /// The <see cref="Size"/> which specifies the rectangles height and width.
+        /// </param>
+        /// <param name="units">The measurement unit of this Rectangle</param>
+        /// <seealso cref="Rectangle"/>
+        public Rectangle(Point point, Size size, MeasurementUnits units = MeasurementUnits.Pixels)
+        {
+            X = (int)point.X;
+            Y = (int)point.Y;
+            Width = size.Width;
+            Height = size.Height;
             Units = units;
         }
 
@@ -93,6 +115,23 @@ namespace IronSoftware.Drawing
             }
 
             throw new NotImplementedException($"Rectangle conversion from {Units} to {units} is not implemented");
+        }
+
+        /// <summary>
+        /// Gets or sets the size of this <see cref="Rectangle"/>.
+        /// </summary>
+        [EditorBrowsable(EditorBrowsableState.Never)]
+        public Size Size
+        {
+            [MethodImpl(MethodImplOptions.AggressiveInlining)]
+            get => new(Width, Height);
+
+            [MethodImpl(MethodImplOptions.AggressiveInlining)]
+            set
+            {
+                Width = value.Width;
+                Height = value.Height;
+            }
         }
 
         /// <summary>

--- a/IronSoftware.Drawing/IronSoftware.Drawing.Common/RectangleF.cs
+++ b/IronSoftware.Drawing/IronSoftware.Drawing.Common/RectangleF.cs
@@ -1,4 +1,6 @@
 ﻿using System;
+using System.ComponentModel;
+using System.Runtime.CompilerServices;
 
 namespace IronSoftware.Drawing
 {
@@ -30,6 +32,26 @@ namespace IronSoftware.Drawing
             Y = y;
             Width = width;
             Height = height;
+            Units = units;
+        }
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="RectangleF"/> struct.
+        /// </summary>
+        /// <param name="point">
+        /// The <see cref="Point"/> which specifies the rectangles point in a two-dimensional plane.
+        /// </param>
+        /// <param name="size">
+        /// The <see cref="Size"/> which specifies the rectangles height and width.
+        /// <param name="units">The measurement unit of this RectangleF</param>
+        /// </param>
+        /// <seealso cref="RectangleF"/>
+        public RectangleF(PointF point, SizeF size, MeasurementUnits units = MeasurementUnits.Pixels)
+        {
+            X = point.X;
+            Y = point.Y;
+            Width = size.Width;
+            Height = size.Height;
             Units = units;
         }
 
@@ -93,6 +115,23 @@ namespace IronSoftware.Drawing
             }
 
             throw new NotImplementedException($"RectangleF conversion from {Units} to {units} is not implemented");
+        }
+        
+        /// <summary>
+        /// Gets or sets the size of this <see cref="RectangleF"/>.
+        /// </summary>
+        [EditorBrowsable(EditorBrowsableState.Never)]
+        public SizeF Size
+        {
+            [MethodImpl(MethodImplOptions.AggressiveInlining)]
+            get => new(Width, Height);
+
+            [MethodImpl(MethodImplOptions.AggressiveInlining)]
+            set
+            {
+                Width = value.Width;
+                Height = value.Height;
+            }
         }
 
         /// <summary>

--- a/IronSoftware.Drawing/IronSoftware.Drawing.Common/Size.cs
+++ b/IronSoftware.Drawing/IronSoftware.Drawing.Common/Size.cs
@@ -1,0 +1,294 @@
+﻿#nullable enable
+
+using System;
+using System.ComponentModel;
+using System.Numerics;
+using System.Runtime.CompilerServices;
+
+namespace IronSoftware.Drawing.Common;
+
+/// <summary>
+/// Stores an ordered pair of integers, which specify a height and width.
+/// </summary>
+/// <remarks>
+/// This struct is fully mutable. This is done (against the guidelines) for the sake of performance,
+/// as it avoids the need to create new values for modification operations.
+/// </remarks>
+public struct Size : IEquatable<Size>
+{
+    /// <summary>
+    /// Represents a <see cref="Size"/> that has Width and Height values set to zero.
+    /// </summary>
+    public static readonly Size Empty;
+
+    /// <summary>
+    /// Initializes a new instance of the <see cref="Size"/> struct.
+    /// </summary>
+    /// <param name="value">The width and height of the size.</param>
+    public Size(int value)
+        : this()
+    {
+        Width = value;
+        Height = value;
+    }
+
+    /// <summary>
+    /// Initializes a new instance of the <see cref="Size"/> struct.
+    /// </summary>
+    /// <param name="width">The width of the size.</param>
+    /// <param name="height">The height of the size.</param>
+    public Size(int width, int height)
+    {
+        Width = width;
+        Height = height;
+    }
+
+    /// <summary>
+    /// Initializes a new instance of the <see cref="Size"/> struct.
+    /// </summary>
+    /// <param name="size">The size.</param>
+    public Size(Size size)
+        : this()
+    {
+        Width = size.Width;
+        Height = size.Height;
+    }
+
+    /// <summary>
+    /// Initializes a new instance of the <see cref="Size"/> struct from the given <see cref="Point"/>.
+    /// </summary>
+    /// <param name="point">The point.</param>
+    public Size(Point point)
+    {
+        Width = (int)point.X;
+        Height = (int)point.Y;
+    }
+
+    /// <summary>
+    /// Gets or sets the width of this <see cref="Size"/>.
+    /// </summary>
+    public int Width { get; set; }
+
+    /// <summary>
+    /// Gets or sets the height of this <see cref="Size"/>.
+    /// </summary>
+    public int Height { get; set; }
+
+    /// <summary>
+    /// Gets a value indicating whether this <see cref="Size"/> is empty.
+    /// </summary>
+    [EditorBrowsable(EditorBrowsableState.Never)]
+    public bool IsEmpty => Equals(Empty);
+
+    /// <summary>
+    /// Creates a <see cref="SizeF"/> with the dimensions of the specified <see cref="Size"/>.
+    /// </summary>
+    /// <param name="size">The point.</param>
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    public static implicit operator SizeF(Size size) => new(size.Width, size.Height);
+
+    /// <summary>
+    /// Converts the given <see cref="Size"/> into a <see cref="Point"/>.
+    /// </summary>
+    /// <param name="size">The size.</param>
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    public static explicit operator Point(Size size) => new(size.Width, size.Height);
+
+    /// <summary>
+    /// Computes the sum of adding two sizes.
+    /// </summary>
+    /// <param name="left">The size on the left hand of the operand.</param>
+    /// <param name="right">The size on the right hand of the operand.</param>
+    /// <returns>
+    /// The <see cref="Size"/>.
+    /// </returns>
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    public static Size operator +(Size left, Size right) => Add(left, right);
+
+    /// <summary>
+    /// Computes the difference left by subtracting one size from another.
+    /// </summary>
+    /// <param name="left">The size on the left hand of the operand.</param>
+    /// <param name="right">The size on the right hand of the operand.</param>
+    /// <returns>
+    /// The <see cref="Size"/>.
+    /// </returns>
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    public static Size operator -(Size left, Size right) => Subtract(left, right);
+
+    /// <summary>
+    /// Multiplies a <see cref="Size"/> by an <see cref="int"/> producing <see cref="Size"/>.
+    /// </summary>
+    /// <param name="left">Multiplier of type <see cref="int"/>.</param>
+    /// <param name="right">Multiplicand of type <see cref="Size"/>.</param>
+    /// <returns>Product of type <see cref="Size"/>.</returns>
+    public static Size operator *(int left, Size right) => Multiply(right, left);
+
+    /// <summary>
+    /// Multiplies <see cref="Size"/> by an <see cref="int"/> producing <see cref="Size"/>.
+    /// </summary>
+    /// <param name="left">Multiplicand of type <see cref="Size"/>.</param>
+    /// <param name="right">Multiplier of type <see cref="int"/>.</param>
+    /// <returns>Product of type <see cref="Size"/>.</returns>
+    public static Size operator *(Size left, int right) => Multiply(left, right);
+
+    /// <summary>
+    /// Divides <see cref="Size"/> by an <see cref="int"/> producing <see cref="Size"/>.
+    /// </summary>
+    /// <param name="left">Dividend of type <see cref="Size"/>.</param>
+    /// <param name="right">Divisor of type <see cref="int"/>.</param>
+    /// <returns>Result of type <see cref="Size"/>.</returns>
+    public static Size operator /(Size left, int right) => new(unchecked(left.Width / right), unchecked(left.Height / right));
+
+    /// <summary>
+    /// Multiplies <see cref="Size"/> by a <see cref="float"/> producing <see cref="SizeF"/>.
+    /// </summary>
+    /// <param name="left">Multiplier of type <see cref="float"/>.</param>
+    /// <param name="right">Multiplicand of type <see cref="Size"/>.</param>
+    /// <returns>Product of type <see cref="SizeF"/>.</returns>
+    public static SizeF operator *(float left, Size right) => Multiply(right, left);
+
+    /// <summary>
+    /// Multiplies <see cref="Size"/> by a <see cref="float"/> producing <see cref="SizeF"/>.
+    /// </summary>
+    /// <param name="left">Multiplicand of type <see cref="Size"/>.</param>
+    /// <param name="right">Multiplier of type <see cref="float"/>.</param>
+    /// <returns>Product of type <see cref="SizeF"/>.</returns>
+    public static SizeF operator *(Size left, float right) => Multiply(left, right);
+
+    /// <summary>
+    /// Divides <see cref="Size"/> by a <see cref="float"/> producing <see cref="SizeF"/>.
+    /// </summary>
+    /// <param name="left">Dividend of type <see cref="Size"/>.</param>
+    /// <param name="right">Divisor of type <see cref="int"/>.</param>
+    /// <returns>Result of type <see cref="SizeF"/>.</returns>
+    public static SizeF operator /(Size left, float right)
+        => new(left.Width / right, left.Height / right);
+
+    /// <summary>
+    /// Compares two <see cref="Size"/> objects for equality.
+    /// </summary>
+    /// <param name="left">
+    /// The <see cref="Size"/> on the left side of the operand.
+    /// </param>
+    /// <param name="right">
+    /// The <see cref="Size"/> on the right side of the operand.
+    /// </param>
+    /// <returns>
+    /// True if the current left is equal to the <paramref name="right"/> parameter; otherwise, false.
+    /// </returns>
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    public static bool operator ==(Size left, Size right) => left.Equals(right);
+
+    /// <summary>
+    /// Compares two <see cref="Size"/> objects for inequality.
+    /// </summary>
+    /// <param name="left">
+    /// The <see cref="Size"/> on the left side of the operand.
+    /// </param>
+    /// <param name="right">
+    /// The <see cref="Size"/> on the right side of the operand.
+    /// </param>
+    /// <returns>
+    /// True if the current left is unequal to the <paramref name="right"/> parameter; otherwise, false.
+    /// </returns>
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    public static bool operator !=(Size left, Size right) => !left.Equals(right);
+
+    /// <summary>
+    /// Performs vector addition of two <see cref="Size"/> objects.
+    /// </summary>
+    /// <param name="left">The size on the left hand of the operand.</param>
+    /// <param name="right">The size on the right hand of the operand.</param>
+    /// <returns>The <see cref="Size"/>.</returns>
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    public static Size Add(Size left, Size right) => new(unchecked(left.Width + right.Width), unchecked(left.Height + right.Height));
+
+    /// <summary>
+    /// Contracts a <see cref="Size"/> by another <see cref="Size"/>.
+    /// </summary>
+    /// <param name="left">The size on the left hand of the operand.</param>
+    /// <param name="right">The size on the right hand of the operand.</param>
+    /// <returns>The <see cref="Size"/>.</returns>
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    public static Size Subtract(Size left, Size right) => new(unchecked(left.Width - right.Width), unchecked(left.Height - right.Height));
+
+    /// <summary>
+    /// Converts a <see cref="SizeF"/> to a <see cref="Size"/> by performing a ceiling operation on all the dimensions.
+    /// </summary>
+    /// <param name="size">The size.</param>
+    /// <returns>The <see cref="Size"/>.</returns>
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    public static Size Ceiling(SizeF size) => new(unchecked((int)MathF.Ceiling(size.Width)), unchecked((int)MathF.Ceiling(size.Height)));
+
+    /// <summary>
+    /// Converts a <see cref="SizeF"/> to a <see cref="Size"/> by performing a round operation on all the dimensions.
+    /// </summary>
+    /// <param name="size">The size.</param>
+    /// <returns>The <see cref="Size"/>.</returns>
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    public static Size Round(SizeF size) => new(unchecked((int)MathF.Round(size.Width)), unchecked((int)MathF.Round(size.Height)));
+
+    /// <summary>
+    /// Transforms a size by the given matrix.
+    /// </summary>
+    /// <param name="size">The source size.</param>
+    /// <param name="matrix">The transformation matrix.</param>
+    /// <returns>A transformed size.</returns>
+    public static SizeF Transform(Size size, Matrix3x2 matrix)
+    {
+        var v = Vector2.Transform(new Vector2(size.Width, size.Height), matrix);
+
+        return new SizeF(v.X, v.Y);
+    }
+
+    /// <summary>
+    /// Converts a <see cref="SizeF"/> to a <see cref="Size"/> by performing a round operation on all the dimensions.
+    /// </summary>
+    /// <param name="size">The size.</param>
+    /// <returns>The <see cref="Size"/>.</returns>
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    public static Size Truncate(SizeF size) => new(unchecked((int)size.Width), unchecked((int)size.Height));
+
+    /// <summary>
+    /// Deconstructs this size into two integers.
+    /// </summary>
+    /// <param name="width">The out value for the width.</param>
+    /// <param name="height">The out value for the height.</param>
+    public void Deconstruct(out int width, out int height)
+    {
+        width = Width;
+        height = Height;
+    }
+
+    /// <inheritdoc/>
+    public override int GetHashCode() => HashCode.Combine(Width, Height);
+
+    /// <inheritdoc/>
+    public override string ToString() => $"Size [ Width={Width}, Height={Height} ]";
+
+    /// <inheritdoc/>
+    public override bool Equals(object? obj) => obj is Size other && Equals(other);
+
+    /// <inheritdoc/>
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    public bool Equals(Size other) => Width.Equals(other.Width) && Height.Equals(other.Height);
+
+    /// <summary>
+    /// Multiplies <see cref="Size"/> by an <see cref="int"/> producing <see cref="Size"/>.
+    /// </summary>
+    /// <param name="size">Multiplicand of type <see cref="Size"/>.</param>
+    /// <param name="multiplier">Multiplier of type <see cref="int"/>.</param>
+    /// <returns>Product of type <see cref="Size"/>.</returns>
+    private static Size Multiply(Size size, int multiplier) =>
+        new(unchecked(size.Width * multiplier), unchecked(size.Height * multiplier));
+
+    /// <summary>
+    /// Multiplies <see cref="Size"/> by a <see cref="float"/> producing <see cref="SizeF"/>.
+    /// </summary>
+    /// <param name="size">Multiplicand of type <see cref="Size"/>.</param>
+    /// <param name="multiplier">Multiplier of type <see cref="float"/>.</param>
+    /// <returns>Product of type SizeF.</returns>
+    private static SizeF Multiply(Size size, float multiplier) =>
+        new(size.Width * multiplier, size.Height * multiplier);
+}

--- a/IronSoftware.Drawing/IronSoftware.Drawing.Common/Size.cs
+++ b/IronSoftware.Drawing/IronSoftware.Drawing.Common/Size.cs
@@ -5,7 +5,7 @@ using System.ComponentModel;
 using System.Numerics;
 using System.Runtime.CompilerServices;
 
-namespace IronSoftware.Drawing.Common;
+namespace IronSoftware.Drawing;
 
 /// <summary>
 /// Stores an ordered pair of integers, which specify a height and width.

--- a/IronSoftware.Drawing/IronSoftware.Drawing.Common/Size.cs
+++ b/IronSoftware.Drawing/IronSoftware.Drawing.Common/Size.cs
@@ -205,6 +205,33 @@ public struct Size : IEquatable<Size>
     }
 
     /// <summary>
+    /// Convert to a <see cref="System.Drawing.Size"/> type.
+    /// </summary>
+    /// <param name="v"></param>
+    public static implicit operator System.Drawing.Size(Size v)
+    {
+        return new System.Drawing.Size(v.Width, v.Height);
+    }
+
+    /// <summary>
+    /// Convert to a <see cref="SkiaSharp.SKSizeI"/> type.
+    /// </summary>
+    /// <param name="v"></param>
+    public static implicit operator SkiaSharp.SKSizeI(Size v)
+    {
+        return new SkiaSharp.SKSizeI(v.Width, v.Height);
+    }
+
+    /// <summary>
+    /// Convert to a <see cref="Microsoft.Maui.Graphics.Size"/> type.
+    /// </summary>
+    /// <param name="v"></param>
+    public static implicit operator Microsoft.Maui.Graphics.Size(Size v)
+    {
+        return new Microsoft.Maui.Graphics.Size(v.Width, v.Height);
+    }
+
+    /// <summary>
     /// Performs vector addition of two <see cref="Size"/> objects.
     /// </summary>
     /// <param name="left">The size on the left hand of the operand.</param>

--- a/IronSoftware.Drawing/IronSoftware.Drawing.Common/Size.cs
+++ b/IronSoftware.Drawing/IronSoftware.Drawing.Common/Size.cs
@@ -196,6 +196,15 @@ public struct Size : IEquatable<Size>
     public static bool operator !=(Size left, Size right) => !left.Equals(right);
 
     /// <summary>
+    /// Convert to a <see cref="SixLabors.ImageSharp.Size"/> type.
+    /// </summary>
+    /// <param name="v"></param>
+    public static implicit operator SixLabors.ImageSharp.Size(Size v)
+    {
+        return new SixLabors.ImageSharp.Size(v.Width, v.Height);
+    }
+
+    /// <summary>
     /// Performs vector addition of two <see cref="Size"/> objects.
     /// </summary>
     /// <param name="left">The size on the left hand of the operand.</param>
@@ -212,22 +221,6 @@ public struct Size : IEquatable<Size>
     /// <returns>The <see cref="Size"/>.</returns>
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
     public static Size Subtract(Size left, Size right) => new(unchecked(left.Width - right.Width), unchecked(left.Height - right.Height));
-
-    /// <summary>
-    /// Converts a <see cref="SizeF"/> to a <see cref="Size"/> by performing a ceiling operation on all the dimensions.
-    /// </summary>
-    /// <param name="size">The size.</param>
-    /// <returns>The <see cref="Size"/>.</returns>
-    [MethodImpl(MethodImplOptions.AggressiveInlining)]
-    public static Size Ceiling(SizeF size) => new(unchecked((int)MathF.Ceiling(size.Width)), unchecked((int)MathF.Ceiling(size.Height)));
-
-    /// <summary>
-    /// Converts a <see cref="SizeF"/> to a <see cref="Size"/> by performing a round operation on all the dimensions.
-    /// </summary>
-    /// <param name="size">The size.</param>
-    /// <returns>The <see cref="Size"/>.</returns>
-    [MethodImpl(MethodImplOptions.AggressiveInlining)]
-    public static Size Round(SizeF size) => new(unchecked((int)MathF.Round(size.Width)), unchecked((int)MathF.Round(size.Height)));
 
     /// <summary>
     /// Transforms a size by the given matrix.
@@ -260,9 +253,6 @@ public struct Size : IEquatable<Size>
         width = Width;
         height = Height;
     }
-
-    /// <inheritdoc/>
-    public override int GetHashCode() => HashCode.Combine(Width, Height);
 
     /// <inheritdoc/>
     public override string ToString() => $"Size [ Width={Width}, Height={Height} ]";

--- a/IronSoftware.Drawing/IronSoftware.Drawing.Common/Size.cs
+++ b/IronSoftware.Drawing/IronSoftware.Drawing.Common/Size.cs
@@ -196,12 +196,30 @@ public struct Size : IEquatable<Size>
     public static bool operator !=(Size left, Size right) => !left.Equals(right);
 
     /// <summary>
+    /// Convert a <see cref="SixLabors.ImageSharp.Size"/> type to a <see cref="Size"/> type.
+    /// </summary>
+    /// <param name="v"></param>
+    public static implicit operator Size(SixLabors.ImageSharp.Size v)
+    {
+        return new Size(v.Width, v.Height);
+    }
+
+    /// <summary>
     /// Convert to a <see cref="SixLabors.ImageSharp.Size"/> type.
     /// </summary>
     /// <param name="v"></param>
     public static implicit operator SixLabors.ImageSharp.Size(Size v)
     {
         return new SixLabors.ImageSharp.Size(v.Width, v.Height);
+    }
+
+    /// <summary>
+    /// Convert a <see cref="System.Drawing.Size"/> type to a <see cref="Size"/> type.
+    /// </summary>
+    /// <param name="v"></param>
+    public static implicit operator Size(System.Drawing.Size v)
+    {
+        return new Size(v.Width, v.Height);
     }
 
     /// <summary>
@@ -214,12 +232,30 @@ public struct Size : IEquatable<Size>
     }
 
     /// <summary>
+    /// Convert a <see cref="SkiaSharp.SKSizeI"/> type to a <see cref="Size"/> type.
+    /// </summary>
+    /// <param name="v"></param>
+    public static implicit operator Size(SkiaSharp.SKSizeI v)
+    {
+        return new Size(v.Width, v.Height);
+    }
+
+    /// <summary>
     /// Convert to a <see cref="SkiaSharp.SKSizeI"/> type.
     /// </summary>
     /// <param name="v"></param>
     public static implicit operator SkiaSharp.SKSizeI(Size v)
     {
         return new SkiaSharp.SKSizeI(v.Width, v.Height);
+    }
+
+    /// <summary>
+    /// Convert a <see cref="Microsoft.Maui.Graphics.Size"/> type to a <see cref="Size"/> type.
+    /// </summary>
+    /// <param name="v"></param>
+    public static implicit operator Size(Microsoft.Maui.Graphics.Size v)
+    {
+        return new Size((int)v.Width, (int)v.Height);
     }
 
     /// <summary>

--- a/IronSoftware.Drawing/IronSoftware.Drawing.Common/Size.cs
+++ b/IronSoftware.Drawing/IronSoftware.Drawing.Common/Size.cs
@@ -308,4 +308,16 @@ public struct Size : IEquatable<Size>
     /// <returns>Product of type SizeF.</returns>
     private static SizeF Multiply(Size size, float multiplier) =>
         new(size.Width * multiplier, size.Height * multiplier);
+
+    /// <summary>
+    /// Calculate a hash code.
+    /// </summary>
+    /// <returns></returns>
+    public override int GetHashCode()
+    {
+        int hashCode = 859600377;
+        hashCode = hashCode * -1521134295 + Width.GetHashCode();
+        hashCode = hashCode * -1521134295 + Height.GetHashCode();
+        return hashCode;
+    }
 }

--- a/IronSoftware.Drawing/IronSoftware.Drawing.Common/SizeF.cs
+++ b/IronSoftware.Drawing/IronSoftware.Drawing.Common/SizeF.cs
@@ -1,0 +1,231 @@
+﻿#nullable enable
+
+using System;
+using System.ComponentModel;
+using System.Numerics;
+using System.Runtime.CompilerServices;
+
+namespace IronSoftware.Drawing.Common;
+
+/// <summary>
+/// Stores an ordered pair of single precision floating points, which specify a height and width.
+/// </summary>
+/// <remarks>
+/// This struct is fully mutable. This is done (against the guidelines) for the sake of performance,
+/// as it avoids the need to create new values for modification operations.
+/// </remarks>
+public struct SizeF : IEquatable<SizeF>
+{
+    /// <summary>
+    /// Represents a <see cref="SizeF"/> that has Width and Height values set to zero.
+    /// </summary>
+    public static readonly SizeF Empty;
+
+    /// <summary>
+    /// Initializes a new instance of the <see cref="SizeF"/> struct.
+    /// </summary>
+    /// <param name="width">The width of the size.</param>
+    /// <param name="height">The height of the size.</param>
+    public SizeF(float width, float height)
+    {
+        Width = width;
+        Height = height;
+    }
+
+    /// <summary>
+    /// Initializes a new instance of the <see cref="SizeF"/> struct.
+    /// </summary>
+    /// <param name="size">The size.</param>
+    public SizeF(SizeF size)
+        : this()
+    {
+        Width = size.Width;
+        Height = size.Height;
+    }
+
+    /// <summary>
+    /// Initializes a new instance of the <see cref="SizeF"/> struct from the given <see cref="PointF"/>.
+    /// </summary>
+    /// <param name="point">The point.</param>
+    public SizeF(PointF point)
+    {
+        Width = point.X;
+        Height = point.Y;
+    }
+
+    /// <summary>
+    /// Gets or sets the width of this <see cref="SizeF"/>.
+    /// </summary>
+    public float Width { get; set; }
+
+    /// <summary>
+    /// Gets or sets the height of this <see cref="SizeF"/>.
+    /// </summary>
+    public float Height { get; set; }
+
+    /// <summary>
+    /// Gets a value indicating whether this <see cref="SizeF"/> is empty.
+    /// </summary>
+    [EditorBrowsable(EditorBrowsableState.Never)]
+    public bool IsEmpty => this.Equals(Empty);
+
+    /// <summary>
+    /// Creates a <see cref="Vector2"/> with the coordinates of the specified <see cref="PointF"/>.
+    /// </summary>
+    /// <param name="point">The point.</param>
+    /// <returns>
+    /// The <see cref="Vector2"/>.
+    /// </returns>
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    public static implicit operator Vector2(SizeF point) => new(point.Width, point.Height);
+
+    /// <summary>
+    /// Creates a <see cref="Size"/> with the dimensions of the specified <see cref="SizeF"/> by truncating each of the dimensions.
+    /// </summary>
+    /// <param name="size">The size.</param>
+    /// <returns>
+    /// The <see cref="Size"/>.
+    /// </returns>
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    public static explicit operator Size(SizeF size) => new(unchecked((int)size.Width), unchecked((int)size.Height));
+
+    /// <summary>
+    /// Converts the given <see cref="SizeF"/> into a <see cref="PointF"/>.
+    /// </summary>
+    /// <param name="size">The size.</param>
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    public static explicit operator PointF(SizeF size) => new(size.Width, size.Height);
+
+    /// <summary>
+    /// Computes the sum of adding two sizes.
+    /// </summary>
+    /// <param name="left">The size on the left hand of the operand.</param>
+    /// <param name="right">The size on the right hand of the operand.</param>
+    /// <returns>
+    /// The <see cref="SizeF"/>.
+    /// </returns>
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    public static SizeF operator +(SizeF left, SizeF right) => Add(left, right);
+
+    /// <summary>
+    /// Computes the difference left by subtracting one size from another.
+    /// </summary>
+    /// <param name="left">The size on the left hand of the operand.</param>
+    /// <param name="right">The size on the right hand of the operand.</param>
+    /// <returns>
+    /// The <see cref="SizeF"/>.
+    /// </returns>
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    public static SizeF operator -(SizeF left, SizeF right) => Subtract(left, right);
+
+    /// <summary>
+    /// Multiplies <see cref="SizeF"/> by a <see cref="float"/> producing <see cref="SizeF"/>.
+    /// </summary>
+    /// <param name="left">Multiplier of type <see cref="float"/>.</param>
+    /// <param name="right">Multiplicand of type <see cref="SizeF"/>.</param>
+    /// <returns>Product of type <see cref="SizeF"/>.</returns>
+    public static SizeF operator *(float left, SizeF right) => Multiply(right, left);
+
+    /// <summary>
+    /// Multiplies <see cref="SizeF"/> by a <see cref="float"/> producing <see cref="SizeF"/>.
+    /// </summary>
+    /// <param name="left">Multiplicand of type <see cref="SizeF"/>.</param>
+    /// <param name="right">Multiplier of type <see cref="float"/>.</param>
+    /// <returns>Product of type <see cref="SizeF"/>.</returns>
+    public static SizeF operator *(SizeF left, float right) => Multiply(left, right);
+
+    /// <summary>
+    /// Divides <see cref="SizeF"/> by a <see cref="float"/> producing <see cref="SizeF"/>.
+    /// </summary>
+    /// <param name="left">Dividend of type <see cref="SizeF"/>.</param>
+    /// <param name="right">Divisor of type <see cref="int"/>.</param>
+    /// <returns>Result of type <see cref="SizeF"/>.</returns>
+    public static SizeF operator /(SizeF left, float right)
+        => new(left.Width / right, left.Height / right);
+
+    /// <summary>
+    /// Compares two <see cref="SizeF"/> objects for equality.
+    /// </summary>
+    /// <param name="left">The size on the left hand of the operand.</param>
+    /// <param name="right">The size on the right hand of the operand.</param>
+    /// <returns>
+    /// True if the current left is equal to the <paramref name="right"/> parameter; otherwise, false.
+    /// </returns>
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    public static bool operator ==(SizeF left, SizeF right) => left.Equals(right);
+
+    /// <summary>
+    /// Compares two <see cref="SizeF"/> objects for inequality.
+    /// </summary>
+    /// <param name="left">The size on the left hand of the operand.</param>
+    /// <param name="right">The size on the right hand of the operand.</param>
+    /// <returns>
+    /// True if the current left is unequal to the <paramref name="right"/> parameter; otherwise, false.
+    /// </returns>
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    public static bool operator !=(SizeF left, SizeF right) => !left.Equals(right);
+
+    /// <summary>
+    /// Performs vector addition of two <see cref="SizeF"/> objects.
+    /// </summary>
+    /// <param name="left">The size on the left hand of the operand.</param>
+    /// <param name="right">The size on the right hand of the operand.</param>
+    /// <returns>The <see cref="SizeF"/>.</returns>
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    public static SizeF Add(SizeF left, SizeF right) => new(left.Width + right.Width, left.Height + right.Height);
+
+    /// <summary>
+    /// Contracts a <see cref="SizeF"/> by another <see cref="SizeF"/>.
+    /// </summary>
+    /// <param name="left">The size on the left hand of the operand.</param>
+    /// <param name="right">The size on the right hand of the operand.</param>
+    /// <returns>The <see cref="SizeF"/>.</returns>
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    public static SizeF Subtract(SizeF left, SizeF right) => new(left.Width - right.Width, left.Height - right.Height);
+
+    /// <summary>
+    /// Transforms a size by the given matrix.
+    /// </summary>
+    /// <param name="size">The source size.</param>
+    /// <param name="matrix">The transformation matrix.</param>
+    /// <returns>A transformed size.</returns>
+    public static SizeF Transform(SizeF size, Matrix3x2 matrix)
+    {
+        var v = Vector2.Transform(new Vector2(size.Width, size.Height), matrix);
+
+        return new SizeF(v.X, v.Y);
+    }
+
+    /// <summary>
+    /// Deconstructs this size into two floats.
+    /// </summary>
+    /// <param name="width">The out value for the width.</param>
+    /// <param name="height">The out value for the height.</param>
+    public void Deconstruct(out float width, out float height)
+    {
+        width = Width;
+        height = Height;
+    }
+
+    /// <inheritdoc/>
+    public override int GetHashCode() => HashCode.Combine(Width, Height);
+
+    /// <inheritdoc/>
+    public override string ToString() => $"SizeF [ Width={Width}, Height={Height} ]";
+
+    /// <inheritdoc/>
+    public override bool Equals(object? obj) => obj is SizeF && Equals((SizeF)obj);
+
+    /// <inheritdoc/>
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    public bool Equals(SizeF other) => Width.Equals(other.Width) && Height.Equals(other.Height);
+
+    /// <summary>
+    /// Multiplies <see cref="SizeF"/> by a <see cref="float"/> producing <see cref="SizeF"/>.
+    /// </summary>
+    /// <param name="size">Multiplicand of type <see cref="SizeF"/>.</param>
+    /// <param name="multiplier">Multiplier of type <see cref="float"/>.</param>
+    /// <returns>Product of type SizeF.</returns>
+    private static SizeF Multiply(SizeF size, float multiplier) =>
+        new(size.Width * multiplier, size.Height * multiplier);
+}

--- a/IronSoftware.Drawing/IronSoftware.Drawing.Common/SizeF.cs
+++ b/IronSoftware.Drawing/IronSoftware.Drawing.Common/SizeF.cs
@@ -67,7 +67,7 @@ public struct SizeF : IEquatable<SizeF>
     /// Gets a value indicating whether this <see cref="SizeF"/> is empty.
     /// </summary>
     [EditorBrowsable(EditorBrowsableState.Never)]
-    public bool IsEmpty => this.Equals(Empty);
+    public bool IsEmpty => Equals(Empty);
 
     /// <summary>
     /// Creates a <see cref="Vector2"/> with the coordinates of the specified <see cref="PointF"/>.
@@ -164,6 +164,42 @@ public struct SizeF : IEquatable<SizeF>
     /// </returns>
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
     public static bool operator !=(SizeF left, SizeF right) => !left.Equals(right);
+
+    /// <summary>
+    /// Convert to a <see cref="System.Drawing.Size"/> type.
+    /// </summary>
+    /// <param name="v"></param>
+    public static implicit operator System.Drawing.SizeF(SizeF v)
+    {
+        return new System.Drawing.SizeF(v.Width, v.Height);
+    }
+
+    /// <summary>
+    /// Convert to a <see cref="SixLabors.ImageSharp.SizeF"/> type.
+    /// </summary>
+    /// <param name="v"></param>
+    public static implicit operator SixLabors.ImageSharp.SizeF(SizeF v)
+    {
+        return new SixLabors.ImageSharp.SizeF(v.Width, v.Height);
+    }
+
+    /// <summary>
+    /// Convert to a <see cref="SkiaSharp.SKSize"/> type.
+    /// </summary>
+    /// <param name="v"></param>
+    public static implicit operator SkiaSharp.SKSize(SizeF v)
+    {
+        return new SkiaSharp.SKSize(v.Width, v.Height);
+    }
+
+    /// <summary>
+    /// Convert to a <see cref="Microsoft.Maui.Graphics.SizeF"/> type.
+    /// </summary>
+    /// <param name="v"></param>
+    public static implicit operator Microsoft.Maui.Graphics.SizeF(SizeF v)
+    {
+        return new Microsoft.Maui.Graphics.Size(v.Width, v.Height);
+    }
 
     /// <summary>
     /// Performs vector addition of two <see cref="SizeF"/> objects.

--- a/IronSoftware.Drawing/IronSoftware.Drawing.Common/SizeF.cs
+++ b/IronSoftware.Drawing/IronSoftware.Drawing.Common/SizeF.cs
@@ -5,7 +5,7 @@ using System.ComponentModel;
 using System.Numerics;
 using System.Runtime.CompilerServices;
 
-namespace IronSoftware.Drawing.Common;
+namespace IronSoftware.Drawing;
 
 /// <summary>
 /// Stores an ordered pair of single precision floating points, which specify a height and width.

--- a/IronSoftware.Drawing/IronSoftware.Drawing.Common/SizeF.cs
+++ b/IronSoftware.Drawing/IronSoftware.Drawing.Common/SizeF.cs
@@ -261,4 +261,16 @@ public struct SizeF : IEquatable<SizeF>
     /// <returns>Product of type SizeF.</returns>
     private static SizeF Multiply(SizeF size, float multiplier) =>
         new(size.Width * multiplier, size.Height * multiplier);
+
+    /// <summary>
+    /// Calculate a hash code.
+    /// </summary>
+    /// <returns></returns>
+    public override int GetHashCode()
+    {
+        int hashCode = 859600377;
+        hashCode = hashCode * -1521134295 + Width.GetHashCode();
+        hashCode = hashCode * -1521134295 + Height.GetHashCode();
+        return hashCode;
+    }
 }

--- a/IronSoftware.Drawing/IronSoftware.Drawing.Common/SizeF.cs
+++ b/IronSoftware.Drawing/IronSoftware.Drawing.Common/SizeF.cs
@@ -166,12 +166,30 @@ public struct SizeF : IEquatable<SizeF>
     public static bool operator !=(SizeF left, SizeF right) => !left.Equals(right);
 
     /// <summary>
+    /// Convert a <see cref="System.Drawing.SizeF"/> type to a <see cref="SizeF"/> type.
+    /// </summary>
+    /// <param name="v"></param>
+    public static implicit operator SizeF(System.Drawing.SizeF v)
+    {
+        return new SizeF(v.Width, v.Height);
+    }
+
+    /// <summary>
     /// Convert to a <see cref="System.Drawing.Size"/> type.
     /// </summary>
     /// <param name="v"></param>
     public static implicit operator System.Drawing.SizeF(SizeF v)
     {
         return new System.Drawing.SizeF(v.Width, v.Height);
+    }
+
+    /// <summary>
+    /// Convert a <see cref="System.Drawing.SizeF"/> type to a <see cref="SizeF"/> type.
+    /// </summary>
+    /// <param name="v"></param>
+    public static implicit operator SizeF(SixLabors.ImageSharp.SizeF v)
+    {
+        return new SizeF(v.Width, v.Height);
     }
 
     /// <summary>
@@ -184,12 +202,30 @@ public struct SizeF : IEquatable<SizeF>
     }
 
     /// <summary>
+    /// Convert a <see cref="SkiaSharp.SKSize"/> type to a <see cref="SizeF"/> type.
+    /// </summary>
+    /// <param name="v"></param>
+    public static implicit operator SizeF(SkiaSharp.SKSize v)
+    {
+        return new SizeF(v.Width, v.Height);
+    }
+
+    /// <summary>
     /// Convert to a <see cref="SkiaSharp.SKSize"/> type.
     /// </summary>
     /// <param name="v"></param>
     public static implicit operator SkiaSharp.SKSize(SizeF v)
     {
         return new SkiaSharp.SKSize(v.Width, v.Height);
+    }
+
+    /// <summary>
+    /// Convert a <see cref="Microsoft.Maui.Graphics.SizeF"/> type to a <see cref="SizeF"/> type.
+    /// </summary>
+    /// <param name="v"></param>
+    public static implicit operator SizeF(Microsoft.Maui.Graphics.SizeF v)
+    {
+        return new SizeF(v.Width, v.Height);
     }
 
     /// <summary>

--- a/IronSoftware.Drawing/IronSoftware.Drawing.Common/SizeF.cs
+++ b/IronSoftware.Drawing/IronSoftware.Drawing.Common/SizeF.cs
@@ -208,9 +208,6 @@ public struct SizeF : IEquatable<SizeF>
     }
 
     /// <inheritdoc/>
-    public override int GetHashCode() => HashCode.Combine(Width, Height);
-
-    /// <inheritdoc/>
     public override string ToString() => $"SizeF [ Width={Width}, Height={Height} ]";
 
     /// <inheritdoc/>

--- a/NuGet/README.md
+++ b/NuGet/README.md
@@ -28,6 +28,15 @@ If you would like to contribute to this open-source project, please visit the pu
   - `SkiaSharp.SKRect`
   - `SkiaSharp.SKRectI`
   - `SixLabors.ImageSharp.Rectangle`
+- **Size**: A universally compatible Size class. Implicit casting between `IronSoftware.Drawing.Size` and the following supported:
+  - `System.Drawing.Size`
+  - `System.Drawing.SizeF`
+  - `SkiaSharp.SKSize`
+  - `SkiaSharp.SKSizeI`
+  - `SixLabors.ImageSharp.Size`
+  - `SixLabors.ImageSharp.SizeF`
+  - `Microsoft.Maui.Graphics.Size`
+  - `Microsoft.Maui.Graphics.SizeF`
 - **Font**: A universally compatible Font class. Implicit casting between `IronSoftware.Drawing.Font` and the following supported:
   - `System.Drawing.Font`
   - `SkiaSharp.SKFont`

--- a/README.md
+++ b/README.md
@@ -44,6 +44,19 @@
 |        `SkiaSharp.SKRectI`       |               ✅              |                ✅               |
 | `SixLabors.ImageSharp.Rectangle` |               ✅              |                ✅               |
 
+- **Size**: A universally compatible Size class. Implicit casting between `IronSoftware.Drawing.Size` and following popular Size formats supported:
+
+|   **Implicit Casting Support**   | To `Size` Supported | From `Size` Supported |
+|--------------------------------|:----------------------------:|:------------------------------:|
+|    `System.Drawing.Size`    |               ✅              |                ✅               |
+|    `System.Drawing.SizeF`    |               ✅              |                ✅               |
+|        `SkiaSharp.SKSize`        |               ✅              |                ✅               |
+|        `SkiaSharp.SKSizeI`       |               ✅              |                ✅               |
+| `SixLabors.ImageSharp.Size` |               ✅              |                ✅    
+| `SixLabors.ImageSharp.SizeF` |               ✅              |                ✅    
+| `Microsoft.Maui.Graphics.Size` |               ✅              |                ✅    
+| `Microsoft.Maui.Graphics.SizeF` |               ✅              |                ✅    
+
 - **Font**: A universally compatible Font class. Implicit casting between `IronSoftware.Drawing.Font` and following popular Font formats supported:
 
 | **Implicit Casting Support** | To `Font` Supported | From `Font` Supported |

--- a/README.md
+++ b/README.md
@@ -178,6 +178,28 @@ ironRectangle.Y;
 ironRectangle.Width;
 ironRectangle.Height;
 ```
+### `Size` Code Example
+```csharp
+using IronSoftware.Drawing;
+
+// Create a new Size object
+Size size = new Size(50, 50);
+
+// Create a new Size object with MeasurementUnits
+Size mmSize = new Size(50, 50, MeasurementUnits.Millimeters);
+
+// Convert between MeasurementUnits
+Size pxSize = mmSize.ConvertTo(MeasurementUnits.Millimeters);
+// Or specify DPI
+Size pxSizeWithDPI = mmSize.ConvertTo(MeasurementUnits.Millimeters, 200);
+
+// Casting between System.Drawing.Size and IronSoftware.Drawing.Size
+System.Drawing.Size size = new System.Drawing.Size(150, 150);
+IronSoftware.Drawing.Size ironSize = size;
+
+ironSize.Width;
+ironSize.Height;
+```
 ### `Font` Code Example
 ```csharp
 using IronSoftware.Drawing;


### PR DESCRIPTION
### Title
Add Size & SizeF structs and modify Rectangle & RectangleF to have constructors that make use of these structs.

### Description
Adds the Size & SizeF structs (somewhat simplified) from SixLabors.

### Fixes #(issue number)
Doesn't fix any particular issue, but will be useful in IronPrint to specify sizes for printing.

### Type of change
Please select the relevant option by placing an 'x' inside the brackets, like this: [x].

- [ ] 🐛 Bug fix (non-breaking change which fixes an issue)
- [x] ✨ New feature (non-breaking change which adds functionality)
- [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] 🏗️ Internal/structural update (non-breaking change that improves code quality, organization, or performance)
- [x] 📚 This change requires a documentation update
- [ ] 🚀 DevOps build chain modification for release
- [ ] 🤖 DevOps build chain modification for CI

### How Has This Been Tested?
Added unit tests from SixLabors.

### Checklist:
Please run through the checklist as much as possible and mark the items completed by placing an 'x' inside the brackets, like this: [x].

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] I have successfully run all unit tests on Windows
- [x] I have successfully run all unit tests on Linux

### Additional Context
Add any other context, screenshots, or information about the pull request here.
