### PR TITLE
Fix typo in AnyBitmap constructor parameter

### DIFF
--- a/CI/azure-pipelines-linux.yml
+++ b/CI/azure-pipelines-linux.yml
@@ -11,6 +11,7 @@ pr:
     include:
     - master
     - main
+    - develop
   paths:
     exclude:
     - NuGet

--- a/CI/azure-pipelines-mac.yml
+++ b/CI/azure-pipelines-mac.yml
@@ -11,6 +11,7 @@ pr:
     include:
     - master
     - main
+    - develop
   paths:
     exclude:
     - NuGet

--- a/CI/azure-pipelines-windows.yml
+++ b/CI/azure-pipelines-windows.yml
@@ -11,6 +11,7 @@ pr:
     include:
     - master
     - main
+    - develop
   paths:
     exclude:
     - NuGet

--- a/IronSoftware.Drawing/IronSoftware.Drawing.Common/AnyBitmap.cs
+++ b/IronSoftware.Drawing/IronSoftware.Drawing.Common/AnyBitmap.cs
@@ -567,10 +567,10 @@ namespace IronSoftware.Drawing
         /// </summary>
         /// <param name="width">Width of new AnyBitmap</param>
         /// <param name="height">Height of new AnyBitmap</param>
-        /// <param name="backgrounColor">Background color of new AnyBitmap</param>
-        public AnyBitmap(int width, int height, Color backgrounColor = null)
+        /// <param name="backgroundColor">Background color of new AnyBitmap</param>
+        public AnyBitmap(int width, int height, Color backgroundColor = null)
         {
-            CreateNewImageInstance(width, height, backgrounColor);
+            CreateNewImageInstance(width, height, backgroundColor);
         }
 
         /// <summary>
@@ -1975,12 +1975,12 @@ namespace IronSoftware.Drawing
 
         #region Private Method
 
-        private void CreateNewImageInstance(int width, int height, Color backgrounColor)
+        private void CreateNewImageInstance(int width, int height, Color backgroundColor)
         {
             Image = new Image<Rgba32>(width, height);
-            if (backgrounColor != null)
+            if (backgroundColor != null)
             {
-                Image.Mutate(context => context.Fill(backgrounColor));
+                Image.Mutate(context => context.Fill(backgroundColor));
             }
             using var stream = new MemoryStream();
             Image.SaveAsBmp(stream);


### PR DESCRIPTION
# Fix typo in AnyBitmap constructor parameter

### Description

Rename `backgrounColor` to `backgroundColor`

Fixes #91

### Type of change

- [ ] 🐛 Bug fix (non-breaking change which fixes an issue)
- [ ] ✨ New feature (non-breaking change which adds functionality)
- [x] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] 🏗️ Internal/structural update (non-breaking change that improves code quality, organization, or performance)
- [ ] 📚 This change requires a documentation update
- [ ] 🚀 DevOps build chain modification for release
- [ ] 🤖 DevOps build chain modification for CI

### How Has This Been Tested?

Tested with CI pipeline

### Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] I have successfully run all unit tests on Windows
- [x] I have successfully run all unit tests on Linux

