### PR TITLE
Fix spelling across the board for 'be cast' -> 'be casted'

### DIFF
--- a/IronSoftware.Drawing/IronSoftware.Drawing.Common/AnyBitmap.cs
+++ b/IronSoftware.Drawing/IronSoftware.Drawing.Common/AnyBitmap.cs
@@ -1134,7 +1134,7 @@ namespace IronSoftware.Drawing
         /// to avoid unnecessary memory allocation.</para>
         /// </summary>
         /// <param name="image">SixLabors.ImageSharp.Image will automatically 
-        /// be cast to <see cref="AnyBitmap"/>.</param>
+        /// be casted to <see cref="AnyBitmap"/>.</param>
         public static implicit operator AnyBitmap(Image<Rgb24> image)
         {
             try
@@ -1266,7 +1266,7 @@ namespace IronSoftware.Drawing
         /// to avoid unnecessary memory allocation.</para>
         /// </summary>
         /// <param name="image">SixLabors.ImageSharp.Image will automatically
-        /// be cast to <see cref="AnyBitmap"/>.</param>
+        /// be casted to <see cref="AnyBitmap"/>.</param>
         public static implicit operator AnyBitmap(Image image)
         {
             try
@@ -1331,7 +1331,7 @@ namespace IronSoftware.Drawing
         /// please remember to dispose your original SkiaSharp.SKImage object
         /// to avoid unnecessary memory allocation.</para>
         /// </summary>
-        /// <param name="image">SkiaSharp.SKImage will automatically be cast to
+        /// <param name="image">SkiaSharp.SKImage will automatically be casted to
         /// <see cref="AnyBitmap"/>.</param>
         public static implicit operator AnyBitmap(SKImage image)
         {
@@ -1407,7 +1407,7 @@ namespace IronSoftware.Drawing
         /// please remember to dispose your original SkiaSharp.SKBitmap object
         /// to avoid unnecessary memory allocation.</para>
         /// </summary>
-        /// <param name="image">SkiaSharp.SKBitmap will automatically be cast
+        /// <param name="image">SkiaSharp.SKBitmap will automatically be casted
         /// to <see cref="AnyBitmap"/>.</param>
         public static implicit operator AnyBitmap(SKBitmap image)
         {
@@ -1486,7 +1486,7 @@ namespace IronSoftware.Drawing
         /// to avoid unnecessary memory allocation.</para>
         /// </summary>
         /// <param name="image">Microsoft.Maui.Graphics.Platform.PlatformImage 
-        /// will automatically be cast to <see cref="AnyBitmap"/>.</param>
+        /// will automatically be casted to <see cref="AnyBitmap"/>.</param>
 
         public static implicit operator AnyBitmap(PlatformImage image)
         {
@@ -1546,7 +1546,7 @@ namespace IronSoftware.Drawing
         /// please remember to dispose your original System.Drawing.Bitmap object
         /// to avoid unnecessary memory allocation.</para>
         /// </summary>
-        /// <param name="image">System.Drawing.Bitmap will automatically be cast to <see cref="AnyBitmap"/> </param>
+        /// <param name="image">System.Drawing.Bitmap will automatically be casted to <see cref="AnyBitmap"/> </param>
         public static implicit operator AnyBitmap(System.Drawing.Bitmap image)
         {
             byte[] data;
@@ -1642,7 +1642,7 @@ namespace IronSoftware.Drawing
         /// please remember to dispose your original System.Drawing.Image object
         /// to avoid unnecessary memory allocation.</para>
         /// </summary>
-        /// <param name="image">System.Drawing.Image will automatically be cast
+        /// <param name="image">System.Drawing.Image will automatically be casted
         /// to <see cref="AnyBitmap"/> </param>
         public static implicit operator AnyBitmap(System.Drawing.Image image)
         {

--- a/IronSoftware.Drawing/IronSoftware.Drawing.Common/Color.cs
+++ b/IronSoftware.Drawing/IronSoftware.Drawing.Common/Color.cs
@@ -949,7 +949,7 @@ namespace IronSoftware.Drawing
         /// Implicitly casts <see cref="System.Drawing.Color"/> objects to <see cref="Color"/>.  
         /// <para>When your .NET Class methods use <see cref="Color"/> as parameters or return types, you now automatically support <see cref="System.Drawing.Color"/> as well.</para>
         /// </summary>
-        /// <param name="color"><see cref="System.Drawing.Color"/> will automatically be cast to <see cref="Color"/> </param>
+        /// <param name="color"><see cref="System.Drawing.Color"/> will automatically be casted to <see cref="Color"/> </param>
         public static implicit operator Color(System.Drawing.Color color)
         {
             return new Color(color.A, color.R, color.G, color.B);
@@ -969,7 +969,7 @@ namespace IronSoftware.Drawing
         /// Implicitly casts <see cref="SkiaSharp.SKColor"/> objects to <see cref="Color"/>.  
         /// <para>When your .NET Class methods use <see cref="Color"/> as parameters or return types, you now automatically support <see cref="SkiaSharp.SKColor"/> as well.</para>
         /// </summary>
-        /// <param name="color"><see cref="SkiaSharp.SKColor"/> will automatically be cast to <see cref="Color"/> </param>
+        /// <param name="color"><see cref="SkiaSharp.SKColor"/> will automatically be casted to <see cref="Color"/> </param>
         public static implicit operator Color(SkiaSharp.SKColor color)
         {
             return new Color(color.Alpha, color.Red, color.Green, color.Blue);
@@ -989,7 +989,7 @@ namespace IronSoftware.Drawing
         /// Implicitly casts <see cref="SixLabors.ImageSharp.Color"/> objects to <see cref="Color"/>.  
         /// <para>When your .NET Class methods use <see cref="Color"/> as parameters or return types, you now automatically support <see cref="SixLabors.ImageSharp.Color"/> as well.</para>
         /// </summary>
-        /// <param name="color"><see cref="SixLabors.ImageSharp.Color"/> will automatically be cast to <see cref="Color"/> </param>
+        /// <param name="color"><see cref="SixLabors.ImageSharp.Color"/> will automatically be casted to <see cref="Color"/> </param>
         public static implicit operator Color(SixLabors.ImageSharp.Color color)
         {
             string hex = color.ToHex();
@@ -1010,7 +1010,7 @@ namespace IronSoftware.Drawing
         /// Implicitly casts <see cref="SixLabors.ImageSharp.PixelFormats.Rgba32"/> objects to <see cref="Color"/>.  
         /// <para>When your .NET Class methods use <see cref="Color"/> as parameters or return types, you now automatically support <see cref="SixLabors.ImageSharp.PixelFormats.Rgba32"/> as well.</para>
         /// </summary>
-        /// <param name="color"><see cref="SixLabors.ImageSharp.PixelFormats.Rgba32"/> will automatically be cast to <see cref="Color"/> </param>
+        /// <param name="color"><see cref="SixLabors.ImageSharp.PixelFormats.Rgba32"/> will automatically be casted to <see cref="Color"/> </param>
         public static implicit operator Color(SixLabors.ImageSharp.PixelFormats.Rgba32 color)
         {
             string hex = color.ToHex(); // Rgba
@@ -1031,7 +1031,7 @@ namespace IronSoftware.Drawing
         /// Implicitly casts <see cref="SixLabors.ImageSharp.PixelFormats.Bgra32"/> objects to <see cref="Color"/>.  
         /// <para>When your .NET Class methods use <see cref="Color"/> as parameters or return types, you now automatically support <see cref="SixLabors.ImageSharp.PixelFormats.Bgra32"/> as well.</para>
         /// </summary>
-        /// <param name="color"><see cref="SixLabors.ImageSharp.PixelFormats.Bgra32"/> will automatically be cast to <see cref="Color"/> </param>
+        /// <param name="color"><see cref="SixLabors.ImageSharp.PixelFormats.Bgra32"/> will automatically be casted to <see cref="Color"/> </param>
         public static implicit operator Color(SixLabors.ImageSharp.PixelFormats.Bgra32 color)
         {
             return new Color(color.R, color.G, color.B, color.A);
@@ -1051,7 +1051,7 @@ namespace IronSoftware.Drawing
         /// Implicitly casts <see cref="SixLabors.ImageSharp.PixelFormats.Rgb24"/> objects to <see cref="Color"/>.  
         /// <para>When your .NET Class methods use <see cref="Color"/> as parameters or return types, you now automatically support <see cref="SixLabors.ImageSharp.PixelFormats.Rgb24"/> as well.</para>
         /// </summary>
-        /// <param name="color"><see cref="SixLabors.ImageSharp.PixelFormats.Rgb24"/> will automatically be cast to <see cref="Color"/> </param>
+        /// <param name="color"><see cref="SixLabors.ImageSharp.PixelFormats.Rgb24"/> will automatically be casted to <see cref="Color"/> </param>
         public static implicit operator Color(SixLabors.ImageSharp.PixelFormats.Rgb24 color)
         {
             return new Color(color.R, color.G, color.B);
@@ -1071,7 +1071,7 @@ namespace IronSoftware.Drawing
         /// Implicitly casts <see cref="SixLabors.ImageSharp.PixelFormats.Bgr24"/> objects to <see cref="Color"/>.  
         /// <para>When your .NET Class methods use <see cref="Color"/> as parameters or return types, you now automatically support <see cref="SixLabors.ImageSharp.PixelFormats.Bgr24"/> as well.</para>
         /// </summary>
-        /// <param name="color"><see cref="SixLabors.ImageSharp.PixelFormats.Bgr24"/> will automatically be cast to <see cref="Color"/> </param>
+        /// <param name="color"><see cref="SixLabors.ImageSharp.PixelFormats.Bgr24"/> will automatically be casted to <see cref="Color"/> </param>
         public static implicit operator Color(SixLabors.ImageSharp.PixelFormats.Bgr24 color)
         {
             return new Color(color.R, color.G, color.B);
@@ -1091,7 +1091,7 @@ namespace IronSoftware.Drawing
         /// Implicitly casts <see cref="SixLabors.ImageSharp.PixelFormats.Rgb48"/> objects to <see cref="Color"/>.  
         /// <para>When your .NET Class methods use <see cref="Color"/> as parameters or return types, you now automatically support <see cref="SixLabors.ImageSharp.PixelFormats.Rgb48"/> as well.</para>
         /// </summary>
-        /// <param name="color"><see cref="SixLabors.ImageSharp.PixelFormats.Rgb48"/> will automatically be cast to <see cref="Color"/> </param>
+        /// <param name="color"><see cref="SixLabors.ImageSharp.PixelFormats.Rgb48"/> will automatically be casted to <see cref="Color"/> </param>
         public static implicit operator Color(SixLabors.ImageSharp.PixelFormats.Rgb48 color)
         {
             return new Color(color.R, color.G, color.B);
@@ -1111,7 +1111,7 @@ namespace IronSoftware.Drawing
         /// Implicitly casts <see cref="SixLabors.ImageSharp.PixelFormats.Rgba64"/> objects to <see cref="Color"/>.  
         /// <para>When your .NET Class methods use <see cref="Color"/> as parameters or return types, you now automatically support <see cref="SixLabors.ImageSharp.PixelFormats.Rgba64"/> as well.</para>
         /// </summary>
-        /// <param name="color"><see cref="SixLabors.ImageSharp.PixelFormats.Rgba64"/> will automatically be cast to <see cref="Color"/> </param>
+        /// <param name="color"><see cref="SixLabors.ImageSharp.PixelFormats.Rgba64"/> will automatically be casted to <see cref="Color"/> </param>
         public static implicit operator Color(SixLabors.ImageSharp.PixelFormats.Rgba64 color)
         {
             return new Color(color.A, color.R, color.G, color.B);
@@ -1131,7 +1131,7 @@ namespace IronSoftware.Drawing
         /// Implicitly casts <see cref="SixLabors.ImageSharp.PixelFormats.Abgr32"/> objects to <see cref="Color"/>.  
         /// <para>When your .NET Class methods use <see cref="Color"/> as parameters or return types, you now automatically support <see cref="SixLabors.ImageSharp.PixelFormats.Abgr32"/> as well.</para>
         /// </summary>
-        /// <param name="color"><see cref="SixLabors.ImageSharp.PixelFormats.Abgr32"/> will automatically be cast to <see cref="Color"/> </param>
+        /// <param name="color"><see cref="SixLabors.ImageSharp.PixelFormats.Abgr32"/> will automatically be casted to <see cref="Color"/> </param>
         public static implicit operator Color(SixLabors.ImageSharp.PixelFormats.Abgr32 color)
         {
             return new Color(color.A, color.R, color.G, color.B);
@@ -1151,7 +1151,7 @@ namespace IronSoftware.Drawing
         /// Implicitly casts <see cref="SixLabors.ImageSharp.PixelFormats.Argb32"/> objects to <see cref="Color"/>.  
         /// <para>When your .NET Class methods use <see cref="Color"/> as parameters or return types, you now automatically support <see cref="SixLabors.ImageSharp.PixelFormats.Argb32"/> as well.</para>
         /// </summary>
-        /// <param name="color"><see cref="SixLabors.ImageSharp.PixelFormats.Argb32"/> will automatically be cast to <see cref="Color"/> </param>
+        /// <param name="color"><see cref="SixLabors.ImageSharp.PixelFormats.Argb32"/> will automatically be casted to <see cref="Color"/> </param>
         public static implicit operator Color(SixLabors.ImageSharp.PixelFormats.Argb32 color)
         {
             return new Color(color.A, color.R, color.G, color.B);
@@ -1171,7 +1171,7 @@ namespace IronSoftware.Drawing
         /// Implicitly casts <see cref="Microsoft.Maui.Graphics.Color"/> objects to <see cref="Color"/>.  
         /// <para>When your .NET Class methods use <see cref="Color"/> as parameters or return types, you now automatically support <see cref="Microsoft.Maui.Graphics.Color"/> as well.</para>
         /// </summary>
-        /// <param name="color"><see cref="Microsoft.Maui.Graphics.Color"/> will automatically be cast to <see cref="Color"/> </param>
+        /// <param name="color"><see cref="Microsoft.Maui.Graphics.Color"/> will automatically be casted to <see cref="Color"/> </param>
         public static implicit operator Color(Microsoft.Maui.Graphics.Color color)
         {
             color.ToRgba(out byte r, out byte g, out byte b, out byte a);

--- a/IronSoftware.Drawing/IronSoftware.Drawing.Common/Font.cs
+++ b/IronSoftware.Drawing/IronSoftware.Drawing.Common/Font.cs
@@ -120,7 +120,7 @@ namespace IronSoftware.Drawing
         /// Implicitly casts System.Drawing.Font objects to <see cref="Font"/>.  
         /// <para>When your .NET Class methods use <see cref="Font"/> as parameters or return types, you now automatically support Font as well.</para>
         /// </summary>
-        /// <param name="font">System.Drawing.Font will automatically be cast to <see cref="Font"/> </param>
+        /// <param name="font">System.Drawing.Font will automatically be casted to <see cref="Font"/> </param>
         public static implicit operator Font(System.Drawing.Font font)
         {
             return new Font(font.FontFamily.Name, (FontStyle)font.Style, font.Size);
@@ -140,7 +140,7 @@ namespace IronSoftware.Drawing
         /// Implicitly casts SixLabors.Fonts.Font objects to <see cref="Font"/>.  
         /// <para>When your .NET Class methods use <see cref="Font"/> as parameters or return types, you now automatically support Font as well.</para>
         /// </summary>
-        /// <param name="font">SixLabors.Fonts.Font will automatically be cast to <see cref="Font"/> </param>
+        /// <param name="font">SixLabors.Fonts.Font will automatically be casted to <see cref="Font"/> </param>
         public static implicit operator Font(SixLabors.Fonts.Font font)
         {
             FontStyle fontStyle;
@@ -178,7 +178,7 @@ namespace IronSoftware.Drawing
         /// Implicitly casts SkiaSharp.SKFont objects to <see cref="Font"/>.  
         /// <para>When your .NET Class methods use <see cref="Font"/> as parameters or return types, you now automatically support Font as well.</para>
         /// </summary>
-        /// <param name="font">SkiaSharp.SKFont will automatically be cast to <see cref="Font"/> </param>
+        /// <param name="font">SkiaSharp.SKFont will automatically be casted to <see cref="Font"/> </param>
         public static implicit operator Font(SkiaSharp.SKFont font)
         {
             FontStyle fontStyle;
@@ -226,7 +226,7 @@ namespace IronSoftware.Drawing
         /// Implicitly casts Microsoft.Maui.Graphics.Font objects to <see cref="Font"/>.  
         /// <para>When your .NET Class methods use <see cref="Font"/> as parameters or return types, you now automatically support Font as well.</para>
         /// </summary>
-        /// <param name="font">Microsoft.Maui.Graphics.Font will automatically be cast to <see cref="Font"/> </param>
+        /// <param name="font">Microsoft.Maui.Graphics.Font will automatically be casted to <see cref="Font"/> </param>
         public static implicit operator Font(Microsoft.Maui.Graphics.Font font)
         {
             FontStyle style;
@@ -276,7 +276,7 @@ namespace IronSoftware.Drawing
         /// Implicitly casts IronPdf.Font.FontTypes objects to <see cref="Font"/>.  
         /// <para>When your .NET Class methods use <see cref="Font"/> as parameters or return types, you now automatically support Font as well.</para>
         /// </summary>
-        /// <param name="fontTypes">IronPdf.Font.FontTypes will automatically be cast to <see cref="Font"/> </param>
+        /// <param name="fontTypes">IronPdf.Font.FontTypes will automatically be casted to <see cref="Font"/> </param>
         public static implicit operator Font(IronSoftware.Drawing.FontTypes fontTypes)
         {
             FontStyle style;

--- a/IronSoftware.Drawing/IronSoftware.Drawing.Common/Legacy/CropRectangle.cs
+++ b/IronSoftware.Drawing/IronSoftware.Drawing.Common/Legacy/CropRectangle.cs
@@ -143,7 +143,7 @@ namespace IronSoftware.Drawing
         /// Implicitly casts System.Drawing.Rectangle objects to <see cref="CropRectangle"/>.
         /// <para>When your .NET Class methods use <see cref="CropRectangle"/> as parameters and return types, you now automatically support Rectangle as well.</para>
         /// </summary>
-        /// <param name="rectangle">System.Drawing.Rectangle will automatically be cast to <see cref="CropRectangle"/>.</param>
+        /// <param name="rectangle">System.Drawing.Rectangle will automatically be casted to <see cref="CropRectangle"/>.</param>
         public static implicit operator CropRectangle(System.Drawing.Rectangle rectangle)
         {
             return new CropRectangle(rectangle.X, rectangle.Y, rectangle.Width, rectangle.Height);
@@ -163,7 +163,7 @@ namespace IronSoftware.Drawing
         /// Implicitly casts SkiaSharp.SKRect objects to <see cref="CropRectangle"/>.
         /// <para>When your .NET Class methods use <see cref="CropRectangle"/> as parameters and return types, you now automatically support SkiaSharp.SKRect as well.</para>
         /// </summary>
-        /// <param name="sKRect">SkiaSharp.SKRect will automatically be cast to <see cref="CropRectangle"/>.</param>
+        /// <param name="sKRect">SkiaSharp.SKRect will automatically be casted to <see cref="CropRectangle"/>.</param>
         public static implicit operator CropRectangle(SkiaSharp.SKRect sKRect)
         {
             SkiaSharp.SKRect standardizedSKRect = sKRect.Standardized;
@@ -184,7 +184,7 @@ namespace IronSoftware.Drawing
         /// Implicitly casts SkiaSharp.SKRectI objects to <see cref="CropRectangle"/>.
         /// <para>When your .NET Class methods use <see cref="CropRectangle"/> as parameters and return types, you now automatically support SkiaSharp.SKRectI as well.</para>
         /// </summary>
-        /// <param name="sKRectI">SkiaSharp.SKRectI will automatically be cast to <see cref="CropRectangle"/>.</param>
+        /// <param name="sKRectI">SkiaSharp.SKRectI will automatically be casted to <see cref="CropRectangle"/>.</param>
         public static implicit operator CropRectangle(SkiaSharp.SKRectI sKRectI)
         {
             SkiaSharp.SKRectI standardizedSKRectI = sKRectI.Standardized;
@@ -205,7 +205,7 @@ namespace IronSoftware.Drawing
         /// Implicitly casts SixLabors.ImageSharp.Rectangle objects to <see cref="CropRectangle"/>.
         /// <para>When your .NET Class methods use <see cref="CropRectangle"/> as parameters and return types, you now automatically support SixLabors.ImageSharp.Rectangle as well.</para>
         /// </summary>
-        /// <param name="rectangle">SixLabors.ImageSharp.Rectangle will automatically be cast to <see cref="CropRectangle"/>.</param>
+        /// <param name="rectangle">SixLabors.ImageSharp.Rectangle will automatically be casted to <see cref="CropRectangle"/>.</param>
         public static implicit operator CropRectangle(SixLabors.ImageSharp.Rectangle rectangle)
         {
             return new CropRectangle(rectangle.X, rectangle.Y, rectangle.Width, rectangle.Height);
@@ -225,7 +225,7 @@ namespace IronSoftware.Drawing
         /// Implicitly casts SixLabors.ImageSharp.RectangleF objects to <see cref="CropRectangle"/>.
         /// <para>When your .NET Class methods use <see cref="CropRectangle"/> as parameters and return types, you now automatically support SixLabors.ImageSharp.RectangleF as well.</para>
         /// </summary>
-        /// <param name="rectangle">SixLabors.ImageSharp.RectangleF will automatically be cast to <see cref="CropRectangle"/>.</param>
+        /// <param name="rectangle">SixLabors.ImageSharp.RectangleF will automatically be casted to <see cref="CropRectangle"/>.</param>
         public static implicit operator CropRectangle(SixLabors.ImageSharp.RectangleF rectangle)
         {
             return new CropRectangle((int)rectangle.X, (int)rectangle.Y, (int)rectangle.Width, (int)rectangle.Height);
@@ -245,7 +245,7 @@ namespace IronSoftware.Drawing
         /// Implicitly casts Microsoft.Maui.Graphics.Rect objects to <see cref="CropRectangle"/>.
         /// <para>When your .NET Class methods use <see cref="CropRectangle"/> as parameters and return types, you now automatically support Microsoft.Maui.Graphics.Rect as well.</para>
         /// </summary>
-        /// <param name="rectangle">Microsoft.Maui.Graphics.Rect will automatically be cast to <see cref="CropRectangle"/>.</param>
+        /// <param name="rectangle">Microsoft.Maui.Graphics.Rect will automatically be casted to <see cref="CropRectangle"/>.</param>
         public static implicit operator CropRectangle(Microsoft.Maui.Graphics.Rect rectangle)
         {
             return new CropRectangle((int)rectangle.X, (int)rectangle.Y, (int)rectangle.Width, (int)rectangle.Height);
@@ -265,7 +265,7 @@ namespace IronSoftware.Drawing
         /// Implicitly casts Microsoft.Maui.Graphics.RectF objects to <see cref="CropRectangle"/>.
         /// <para>When your .NET Class methods use <see cref="CropRectangle"/> as parameters and return types, you now automatically support Microsoft.Maui.Graphics.RectF as well.</para>
         /// </summary>
-        /// <param name="rectangle">Microsoft.Maui.Graphics.RectF will automatically be cast to <see cref="CropRectangle"/>.</param>
+        /// <param name="rectangle">Microsoft.Maui.Graphics.RectF will automatically be casted to <see cref="CropRectangle"/>.</param>
         public static implicit operator CropRectangle(Microsoft.Maui.Graphics.RectF rectangle)
         {
             return new CropRectangle((int)rectangle.X, (int)rectangle.Y, (int)rectangle.Width, (int)rectangle.Height);
@@ -284,7 +284,7 @@ namespace IronSoftware.Drawing
         /// <summary>
         /// Implicitly casts new Rectangle objects to deprecated CropRectangle
         /// </summary>
-        /// <param name="rectangle">Rectangle will automatically be cast to CropRectangle</param>
+        /// <param name="rectangle">Rectangle will automatically be casted to CropRectangle</param>
         public static implicit operator CropRectangle(Rectangle rectangle)
         {
             return new CropRectangle
@@ -300,7 +300,7 @@ namespace IronSoftware.Drawing
         /// <summary>
         /// Implicitly casts deprecated CropRectangle objects to new Rectangle
         /// </summary>
-        /// <param name="rectangle">CropRectangle will automatically be cast to Rectangle</param>
+        /// <param name="rectangle">CropRectangle will automatically be casted to Rectangle</param>
         public static implicit operator Rectangle(CropRectangle rectangle)
         {
             return new Rectangle

--- a/IronSoftware.Drawing/IronSoftware.Drawing.Common/Point.cs
+++ b/IronSoftware.Drawing/IronSoftware.Drawing.Common/Point.cs
@@ -43,7 +43,7 @@ namespace IronSoftware.Drawing
         /// <summary>
         /// Implicitly casts SixLabors.ImageSharp.Point objects to Point
         /// </summary>
-        /// <param name="point">System.Drawing.Point will automatically be cast to <see cref="Point"/> </param>
+        /// <param name="point">System.Drawing.Point will automatically be casted to <see cref="Point"/> </param>
         public static implicit operator Point(SixLabors.ImageSharp.Point point)
         {
             return new Point(point.X, point.Y);
@@ -53,7 +53,7 @@ namespace IronSoftware.Drawing
         /// Implicitly casts Point objects to SixLabors.ImageSharp.Point
         /// </summary>
         /// <remarks>SixLabors.ImageSharp.Point only uses int instead of double for X and Y. Decimals will be removed.</remarks>
-        /// <param name="point">Point will automatically be cast to SixLabors.ImageSharp.Point</param>
+        /// <param name="point">Point will automatically be casted to SixLabors.ImageSharp.Point</param>
         public static implicit operator SixLabors.ImageSharp.Point(Point point)
         {
             return new SixLabors.ImageSharp.Point((int)point.X, (int)point.Y);
@@ -62,7 +62,7 @@ namespace IronSoftware.Drawing
         /// <summary>
         /// Implicitly casts System.Drawing.Point objects to <see cref="Point"/>.
         /// </summary>
-        /// <param name="point">System.Drawing.Point will automatically be cast to <see cref="Point"/> </param>
+        /// <param name="point">System.Drawing.Point will automatically be casted to <see cref="Point"/> </param>
         public static implicit operator Point(System.Drawing.Point point)
         {
             return new Point(point.X, point.Y);
@@ -72,7 +72,7 @@ namespace IronSoftware.Drawing
         /// Implicitly casts Point objects to System.Drawing.Point
         /// </summary>
         /// <remarks>System.Drawing.Point only uses int instead of double for X and Y. Decimals will be removed.</remarks>
-        /// <param name="point">Point will automatically be cast to System.Drawing.Point</param>
+        /// <param name="point">Point will automatically be casted to System.Drawing.Point</param>
         public static implicit operator System.Drawing.Point(Point point)
         {
             return new System.Drawing.Point((int)point.X, (int)point.Y);
@@ -81,7 +81,7 @@ namespace IronSoftware.Drawing
         /// <summary>
         /// Implicitly casts Microsoft.Maui.Graphics.Point objects to <see cref="Point"/>.
         /// </summary>
-        /// <param name="point">Microsoft.Maui.Graphics.Point will automatically be cast to <see cref="Point"/> </param>
+        /// <param name="point">Microsoft.Maui.Graphics.Point will automatically be casted to <see cref="Point"/> </param>
         public static implicit operator Point(Microsoft.Maui.Graphics.Point point)
         {
             return new Point(point.X, point.Y);
@@ -90,7 +90,7 @@ namespace IronSoftware.Drawing
         /// <summary>
         /// Implicitly casts Point objects to Microsoft.Maui.Graphics.Point
         /// </summary>
-        /// <param name="point">Point will automatically be cast to Microsoft.Maui.Graphics.Point</param>
+        /// <param name="point">Point will automatically be casted to Microsoft.Maui.Graphics.Point</param>
         public static implicit operator Microsoft.Maui.Graphics.Point(Point point)
         {
             return new Microsoft.Maui.Graphics.Point(point.X, point.Y);
@@ -99,7 +99,7 @@ namespace IronSoftware.Drawing
         /// <summary>
         /// Implicitly casts SkiaSharp.SKPointI objects to <see cref="Point"/>.
         /// </summary>
-        /// <param name="point">SkiaSharp.SKPointI will automatically be cast to <see cref="Point"/> </param>
+        /// <param name="point">SkiaSharp.SKPointI will automatically be casted to <see cref="Point"/> </param>
         public static implicit operator Point(SkiaSharp.SKPointI point)
         {
             return new Point(point.X, point.Y);
@@ -109,7 +109,7 @@ namespace IronSoftware.Drawing
         /// Implicitly casts Point objects to SkiaSharp.SKPointI
         /// </summary>
         /// <remarks>SkiaSharp.SKPointI only uses int instead of double for X and Y. Decimals will be removed.</remarks>
-        /// <param name="point">Point will automatically be cast to SkiaSharp.SKPointI</param>
+        /// <param name="point">Point will automatically be casted to SkiaSharp.SKPointI</param>
         public static implicit operator SkiaSharp.SKPointI(Point point)
         {
             return new SkiaSharp.SKPointI((int)point.X, (int)point.Y);

--- a/IronSoftware.Drawing/IronSoftware.Drawing.Common/PointF.cs
+++ b/IronSoftware.Drawing/IronSoftware.Drawing.Common/PointF.cs
@@ -43,7 +43,7 @@ namespace IronSoftware.Drawing
         /// <summary>
         /// Implicitly casts SixLabors.ImageSharp.PointF objects to PointF
         /// </summary>
-        /// <param name="point">SixLabors.ImageSharp.PointF will automatically be cast to PointF</param>
+        /// <param name="point">SixLabors.ImageSharp.PointF will automatically be casted to PointF</param>
         public static implicit operator PointF(SixLabors.ImageSharp.PointF point)
         {
             return new PointF(point.X, point.Y);
@@ -52,7 +52,7 @@ namespace IronSoftware.Drawing
         /// <summary>
         /// Implicitly casts a PointF object to SixLabors.ImageSharp.PointF
         /// </summary>
-        /// <param name="point">PointF will automatically be cast to SixLabors.ImageSharp.PointF</param>
+        /// <param name="point">PointF will automatically be casted to SixLabors.ImageSharp.PointF</param>
         public static implicit operator SixLabors.ImageSharp.PointF(PointF point)
         {
             return new SixLabors.ImageSharp.PointF(point.X, point.Y);
@@ -61,7 +61,7 @@ namespace IronSoftware.Drawing
         /// <summary>
         /// Implicitly casts Microsoft.Maui.Graphics.Point objects to PointF
         /// </summary>
-        /// <param name="point">Microsoft.Maui.Graphics.Point will automatically be cast to PointF</param>
+        /// <param name="point">Microsoft.Maui.Graphics.Point will automatically be casted to PointF</param>
         public static implicit operator PointF(Microsoft.Maui.Graphics.PointF point)
         {
             return new PointF(point.X, point.Y);
@@ -70,7 +70,7 @@ namespace IronSoftware.Drawing
         /// <summary>
         /// Implicitly casts PointF objects to Microsoft.Maui.Graphics.Point
         /// </summary>
-        /// <param name="point">PointF will automatically be cast to Microsoft.Maui.Graphics.Point</param>
+        /// <param name="point">PointF will automatically be casted to Microsoft.Maui.Graphics.Point</param>
         public static implicit operator Microsoft.Maui.Graphics.PointF(PointF point)
         {
             return new Microsoft.Maui.Graphics.PointF(point.X, point.Y);
@@ -79,7 +79,7 @@ namespace IronSoftware.Drawing
         /// <summary>
         /// Implicitly casts SkiaSharp.SKPoint objects to PointF
         /// </summary>
-        /// <param name="point">SkiaSharp.SKPoint will automatically be cast to PointF</param>
+        /// <param name="point">SkiaSharp.SKPoint will automatically be casted to PointF</param>
         public static implicit operator PointF(SkiaSharp.SKPoint point)
         {
             return new PointF(point.X, point.Y);
@@ -88,7 +88,7 @@ namespace IronSoftware.Drawing
         /// <summary>
         /// Implicitly casts PointF objects to SkiaSharp.SKPoint
         /// </summary>
-        /// <param name="point">PointF will automatically be cast to SkiaSharp.SKPoint</param>
+        /// <param name="point">PointF will automatically be casted to SkiaSharp.SKPoint</param>
         public static implicit operator SkiaSharp.SKPoint(PointF point)
         {
             return new SkiaSharp.SKPoint(point.X, point.Y);

--- a/IronSoftware.Drawing/IronSoftware.Drawing.Common/Rectangle.cs
+++ b/IronSoftware.Drawing/IronSoftware.Drawing.Common/Rectangle.cs
@@ -185,7 +185,7 @@ namespace IronSoftware.Drawing
         /// Implicitly casts System.Drawing.Rectangle objects to <see cref="Rectangle"/>.
         /// <para>When your .NET Class methods use <see cref="Rectangle"/> as parameters and return types, you now automatically support Rectangle as well.</para>
         /// </summary>
-        /// <param name="rectangle">System.Drawing.Rectangle will automatically be cast to <see cref="Rectangle"/>.</param>
+        /// <param name="rectangle">System.Drawing.Rectangle will automatically be casted to <see cref="Rectangle"/>.</param>
         public static implicit operator Rectangle(System.Drawing.Rectangle rectangle)
         {
             return new Rectangle(rectangle.X, rectangle.Y, rectangle.Width, rectangle.Height);
@@ -205,7 +205,7 @@ namespace IronSoftware.Drawing
         /// Implicitly casts SkiaSharp.SKRect objects to <see cref="Rectangle"/>.
         /// <para>When your .NET Class methods use <see cref="Rectangle"/> as parameters and return types, you now automatically support SkiaSharp.SKRect as well.</para>
         /// </summary>
-        /// <param name="sKRect">SkiaSharp.SKRect will automatically be cast to <see cref="Rectangle"/>.</param>
+        /// <param name="sKRect">SkiaSharp.SKRect will automatically be casted to <see cref="Rectangle"/>.</param>
         public static implicit operator Rectangle(SkiaSharp.SKRect sKRect)
         {
             SkiaSharp.SKRect standardizedSKRect = sKRect.Standardized;
@@ -226,7 +226,7 @@ namespace IronSoftware.Drawing
         /// Implicitly casts SkiaSharp.SKRectI objects to <see cref="Rectangle"/>.
         /// <para>When your .NET Class methods use <see cref="Rectangle"/> as parameters and return types, you now automatically support SkiaSharp.SKRectI as well.</para>
         /// </summary>
-        /// <param name="sKRectI">SkiaSharp.SKRectI will automatically be cast to <see cref="Rectangle"/>.</param>
+        /// <param name="sKRectI">SkiaSharp.SKRectI will automatically be casted to <see cref="Rectangle"/>.</param>
         public static implicit operator Rectangle(SkiaSharp.SKRectI sKRectI)
         {
             SkiaSharp.SKRectI standardizedSKRectI = sKRectI.Standardized;
@@ -247,7 +247,7 @@ namespace IronSoftware.Drawing
         /// Implicitly casts SixLabors.ImageSharp.Rectangle objects to <see cref="Rectangle"/>.
         /// <para>When your .NET Class methods use <see cref="Rectangle"/> as parameters and return types, you now automatically support SixLabors.ImageSharp.Rectangle as well.</para>
         /// </summary>
-        /// <param name="rectangle">SixLabors.ImageSharp.Rectangle will automatically be cast to <see cref="Rectangle"/>.</param>
+        /// <param name="rectangle">SixLabors.ImageSharp.Rectangle will automatically be casted to <see cref="Rectangle"/>.</param>
         public static implicit operator Rectangle(SixLabors.ImageSharp.Rectangle rectangle)
         {
             return new Rectangle(rectangle.X, rectangle.Y, rectangle.Width, rectangle.Height);
@@ -267,7 +267,7 @@ namespace IronSoftware.Drawing
         /// Implicitly casts SixLabors.ImageSharp.RectangleF objects to <see cref="Rectangle"/>.
         /// <para>When your .NET Class methods use <see cref="Rectangle"/> as parameters and return types, you now automatically support SixLabors.ImageSharp.RectangleF as well.</para>
         /// </summary>
-        /// <param name="rectangle">SixLabors.ImageSharp.RectangleF will automatically be cast to <see cref="Rectangle"/>.</param>
+        /// <param name="rectangle">SixLabors.ImageSharp.RectangleF will automatically be casted to <see cref="Rectangle"/>.</param>
         public static implicit operator Rectangle(SixLabors.ImageSharp.RectangleF rectangle)
         {
             return new Rectangle((int)rectangle.X, (int)rectangle.Y, (int)rectangle.Width, (int)rectangle.Height);
@@ -287,7 +287,7 @@ namespace IronSoftware.Drawing
         /// Implicitly casts Microsoft.Maui.Graphics.Rect objects to <see cref="Rectangle"/>.
         /// <para>When your .NET Class methods use <see cref="Rectangle"/> as parameters and return types, you now automatically support Microsoft.Maui.Graphics.Rect as well.</para>
         /// </summary>
-        /// <param name="rectangle">Microsoft.Maui.Graphics.Rect will automatically be cast to <see cref="Rectangle"/>.</param>
+        /// <param name="rectangle">Microsoft.Maui.Graphics.Rect will automatically be casted to <see cref="Rectangle"/>.</param>
         public static implicit operator Rectangle(Microsoft.Maui.Graphics.Rect rectangle)
         {
             return new Rectangle((int)rectangle.X, (int)rectangle.Y, (int)rectangle.Width, (int)rectangle.Height);
@@ -307,7 +307,7 @@ namespace IronSoftware.Drawing
         /// Implicitly casts Microsoft.Maui.Graphics.RectF objects to <see cref="Rectangle"/>.
         /// <para>When your .NET Class methods use <see cref="Rectangle"/> as parameters and return types, you now automatically support Microsoft.Maui.Graphics.RectF as well.</para>
         /// </summary>
-        /// <param name="rectangle">Microsoft.Maui.Graphics.RectF will automatically be cast to <see cref="Rectangle"/>.</param>
+        /// <param name="rectangle">Microsoft.Maui.Graphics.RectF will automatically be casted to <see cref="Rectangle"/>.</param>
         public static implicit operator Rectangle(Microsoft.Maui.Graphics.RectF rectangle)
         {
             return new Rectangle((int)rectangle.X, (int)rectangle.Y, (int)rectangle.Width, (int)rectangle.Height);

--- a/IronSoftware.Drawing/IronSoftware.Drawing.Common/RectangleF.cs
+++ b/IronSoftware.Drawing/IronSoftware.Drawing.Common/RectangleF.cs
@@ -175,7 +175,7 @@ namespace IronSoftware.Drawing
         /// Implicitly casts System.Drawing.RectangleF objects to <see cref="RectangleF"/>.
         /// <para>When your .NET Class methods use <see cref="RectangleF"/> as parameters and return types, you now automatically support RectangleF as well.</para>
         /// </summary>
-        /// <param name="RectangleF">System.Drawing.RectangleF will automatically be cast to <see cref="RectangleF"/>.</param>
+        /// <param name="RectangleF">System.Drawing.RectangleF will automatically be casted to <see cref="RectangleF"/>.</param>
         public static implicit operator RectangleF(System.Drawing.RectangleF RectangleF)
         {
             return new RectangleF(RectangleF.X, RectangleF.Y, RectangleF.Width, RectangleF.Height);
@@ -195,7 +195,7 @@ namespace IronSoftware.Drawing
         /// Implicitly casts SkiaSharp.SKRect objects to <see cref="RectangleF"/>.
         /// <para>When your .NET Class methods use <see cref="RectangleF"/> as parameters and return types, you now automatically support SkiaSharp.SKRect as well.</para>
         /// </summary>
-        /// <param name="sKRect">SkiaSharp.SKRect will automatically be cast to <see cref="RectangleF"/>.</param>
+        /// <param name="sKRect">SkiaSharp.SKRect will automatically be casted to <see cref="RectangleF"/>.</param>
         public static implicit operator RectangleF(SkiaSharp.SKRect sKRect)
         {
             SkiaSharp.SKRect standardizedSKRect = sKRect.Standardized;
@@ -216,7 +216,7 @@ namespace IronSoftware.Drawing
         /// Implicitly casts SixLabors.ImageSharp.RectangleF objects to <see cref="RectangleF"/>.
         /// <para>When your .NET Class methods use <see cref="RectangleF"/> as parameters and return types, you now automatically support SixLabors.ImageSharp.RectangleF as well.</para>
         /// </summary>
-        /// <param name="RectangleF">SixLabors.ImageSharp.RectangleF will automatically be cast to <see cref="RectangleF"/>.</param>
+        /// <param name="RectangleF">SixLabors.ImageSharp.RectangleF will automatically be casted to <see cref="RectangleF"/>.</param>
         public static implicit operator RectangleF(SixLabors.ImageSharp.RectangleF RectangleF)
         {
             return new RectangleF(RectangleF.X, RectangleF.Y, RectangleF.Width, RectangleF.Height);
@@ -236,7 +236,7 @@ namespace IronSoftware.Drawing
         /// Implicitly casts Microsoft.Maui.Graphics.Rect objects to <see cref="RectangleF"/>.
         /// <para>When your .NET Class methods use <see cref="RectangleF"/> as parameters and return types, you now automatically support Microsoft.Maui.Graphics.Rect as well.</para>
         /// </summary>
-        /// <param name="RectangleF">Microsoft.Maui.Graphics.Rect will automatically be cast to <see cref="RectangleF"/>.</param>
+        /// <param name="RectangleF">Microsoft.Maui.Graphics.Rect will automatically be casted to <see cref="RectangleF"/>.</param>
         public static implicit operator RectangleF(Microsoft.Maui.Graphics.Rect RectangleF)
         {
             return new RectangleF((float)RectangleF.X, (float)RectangleF.Y, (float)RectangleF.Width, (float)RectangleF.Height);
@@ -256,7 +256,7 @@ namespace IronSoftware.Drawing
         /// Implicitly casts Microsoft.Maui.Graphics.RectF objects to <see cref="RectangleF"/>.
         /// <para>When your .NET Class methods use <see cref="RectangleF"/> as parameters and return types, you now automatically support Microsoft.Maui.Graphics.RectF as well.</para>
         /// </summary>
-        /// <param name="RectangleF">Microsoft.Maui.Graphics.RectF will automatically be cast to <see cref="RectangleF"/>.</param>
+        /// <param name="RectangleF">Microsoft.Maui.Graphics.RectF will automatically be casted to <see cref="RectangleF"/>.</param>
         public static implicit operator RectangleF(Microsoft.Maui.Graphics.RectF RectangleF)
         {
             return new RectangleF(RectangleF.X, RectangleF.Y, RectangleF.Width, RectangleF.Height);


### PR DESCRIPTION
### Title
Fix spelling across the board for 'be cast' -> 'be casted'

Fixes #(issue number)
N/A

### Type of change
Please select the relevant option by placing an 'x' inside the brackets, like this: [x].

- [ ] 🐛 Bug fix (non-breaking change which fixes an issue)
- [ ] ✨ New feature (non-breaking change which adds functionality)
- [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] 🏗️ Internal/structural update (non-breaking change that improves code quality, organization, or performance)
- [ ] 📚 This change requires a documentation update
- [ ] 🚀 DevOps build chain modification for release
- [ ] 🤖 DevOps build chain modification for CI
