### PR TITLE
Update SixLabors version

### DIFF
--- a/IronSoftware.Drawing/IronSoftware.Drawing.Common/IronSoftware.Drawing.Common.csproj
+++ b/IronSoftware.Drawing/IronSoftware.Drawing.Common/IronSoftware.Drawing.Common.csproj
@@ -35,12 +35,12 @@
 		<When Condition="'$(TargetFramework)' == 'net60'">
 			<ItemGroup>
 				<PackageReference Include="SixLabors.ImageSharp" Version="3.1.3" />
-				<PackageReference Include="SixLabors.ImageSharp.Drawing" Version="2.1.1" />
+				<PackageReference Include="SixLabors.ImageSharp.Drawing" Version="2.1.2" />
 			</ItemGroup>
 		</When>
 		<Otherwise>
 			<ItemGroup>
-				<PackageReference Include="SixLabors.ImageSharp" Version="2.1.6" />
+				<PackageReference Include="SixLabors.ImageSharp" Version="2.1.7" />
 				<PackageReference Include="SixLabors.ImageSharp.Drawing" Version="1.0.0" />
 			</ItemGroup>
 		</Otherwise>

--- a/IronSoftware.Drawing/IronSoftware.Drawing.Common/IronSoftware.Drawing.Common.csproj
+++ b/IronSoftware.Drawing/IronSoftware.Drawing.Common/IronSoftware.Drawing.Common.csproj
@@ -34,8 +34,8 @@
 	<Choose>
 		<When Condition="'$(TargetFramework)' == 'net60'">
 			<ItemGroup>
-				<PackageReference Include="SixLabors.ImageSharp" Version="3.0.2" />
-				<PackageReference Include="SixLabors.ImageSharp.Drawing" Version="2.0.0" />
+				<PackageReference Include="SixLabors.ImageSharp" Version="3.1.3" />
+				<PackageReference Include="SixLabors.ImageSharp.Drawing" Version="2.1.1" />
 			</ItemGroup>
 		</When>
 		<Otherwise>

--- a/IronSoftware.Drawing/nuget.config
+++ b/IronSoftware.Drawing/nuget.config
@@ -2,7 +2,6 @@
 <configuration>
 	<packageSources>
 		<clear />
-		<add key="IronCommon" value="https://pkgs.dev.azure.com/ironcoders/IronCommon/_packaging/IronCommon/nuget/v3/index.json" />
 		<add key="nuget.org" value="https://api.nuget.org/v3/index.json" />
 	</packageSources>
 </configuration>

--- a/NuGet/IronSoftware.Drawing.nuspec
+++ b/NuGet/IronSoftware.Drawing.nuspec
@@ -36,7 +36,7 @@ Supports:
 
 For general support and technical inquiries, please email us at: developers@ironsoftware.com</description>
 		<summary>IronSoftware.System.Drawing is an open-source solution for .NET developers to replace System.Drawing.Common with a universal and flexible library.</summary>
-		<releaseNotes>- Changes CropRectangle class to Rectangle</releaseNotes>
+		<releaseNotes>- Update SixLabors.ImageSharp &amp; SixLabors.ImageSharp.Drawing</releaseNotes>
 		<copyright>Copyright © Iron Software 2022-2023</copyright>
 		<tags>Images, Bitmap, SkiaSharp, SixLabors, BitMiracle, Maui, SVG, TIFF, TIF, GIF, JPEG, PNG, Color, Rectangle, Drawing, C#, VB.NET, ASPX, create, render, generate, standard, netstandard2.0, core, netcore</tags>
 		<repository type="git" url="https://github.com/iron-software/IronSoftware.Drawing.Common" commit="$commit$" />
@@ -48,8 +48,8 @@ For general support and technical inquiries, please email us at: developers@iron
 				<dependency id="System.Memory" version="4.5.5" />
 			</group>
 			<group targetFramework="net60">
-				<dependency id="SixLabors.ImageSharp" version="3.0.2" />
-				<dependency id="SixLabors.ImageSharp.Drawing" version="2.0.0" />
+				<dependency id="SixLabors.ImageSharp" version="3.1.3" />
+				<dependency id="SixLabors.ImageSharp.Drawing" version="2.1.1" />
 				<dependency id="BitMiracle.LibTiff.NET" version="2.4.649" />
 				<dependency id="System.Memory" version="4.5.5" />
 			</group>

--- a/NuGet/IronSoftware.Drawing.nuspec
+++ b/NuGet/IronSoftware.Drawing.nuspec
@@ -42,19 +42,19 @@ For general support and technical inquiries, please email us at: developers@iron
 		<repository type="git" url="https://github.com/iron-software/IronSoftware.Drawing.Common" commit="$commit$" />
 		<dependencies>
 			<group targetFramework="netstandard2.0">
-				<dependency id="SixLabors.ImageSharp" version="2.1.6" />
+				<dependency id="SixLabors.ImageSharp" version="2.1.7" />
 				<dependency id="SixLabors.ImageSharp.Drawing" version="1.0.0" />
 				<dependency id="BitMiracle.LibTiff.NET" version="2.4.649" />
 				<dependency id="System.Memory" version="4.5.5" />
 			</group>
 			<group targetFramework="net60">
 				<dependency id="SixLabors.ImageSharp" version="3.1.3" />
-				<dependency id="SixLabors.ImageSharp.Drawing" version="2.1.1" />
+				<dependency id="SixLabors.ImageSharp.Drawing" version="2.1.2" />
 				<dependency id="BitMiracle.LibTiff.NET" version="2.4.649" />
 				<dependency id="System.Memory" version="4.5.5" />
 			</group>
 			<group targetFramework="MonoAndroid10.0">
-				<dependency id="SixLabors.ImageSharp" version="2.1.6" />
+				<dependency id="SixLabors.ImageSharp" version="2.1.7" />
 				<dependency id="SixLabors.ImageSharp.Drawing" version="1.0.0" />
 				<dependency id="BitMiracle.LibTiff.NET" version="2.4.649" />
 				<dependency id="System.Memory" version="4.5.5" />


### PR DESCRIPTION
### Description
Upgrade SixLabors.ImageSharp to v3.1.3 that vulnerable free for NET6.0 or greater.
Upgrade SixLabors.ImageSharp to v2.1.7 that vulnerable free for netstandard2.0.