### PR TITLE
Cleanup .NET Framework Targets

### DIFF
--- a/CI/job_templates/build_drawing_libraries.yml
+++ b/CI/job_templates/build_drawing_libraries.yml
@@ -32,26 +32,6 @@ jobs:
       displayName: Checkout IronSoftware.Drawing repository
       lfs: true
     - task: UseDotNet@2
-      displayName: 'Install .Netcoreapp3.1 Core sdk'
-      inputs:
-        packageType: 'sdk'
-        version: '3.x'
-    - task: UseDotNet@2
-      displayName: 'Install .NET5 sdk'
-      inputs:
-        packageType: 'sdk'
-        version: '5.x'
-    - task: UseDotNet@2
-      displayName: 'Install .NET6 sdk'
-      inputs:
-        packageType: 'sdk'
-        version: '6.x'
-    - task: UseDotNet@2
-      displayName: 'Install .NET7 sdk'
-      inputs:
-        packageType: 'sdk'
-        version: '7.x'
-    - task: UseDotNet@2
       displayName: 'Install .NET7 sdk'
       inputs:
         packageType: 'sdk'

--- a/CI/stage_templates/run_tests_on_pool.yml
+++ b/CI/stage_templates/run_tests_on_pool.yml
@@ -32,59 +32,11 @@ stages:
           framework: 'net472'
           architecture: ''
           buildConfiguration: $(Configuration)
-      # Windows .NET Core x64 Tests
-      - template: ../job_templates/test_drawing_libraries.yml
-        parameters:
-          name: UnitTest${{ parameters.OSPlatform }}netcore
-          OSPlatform: ${{ parameters.OSPlatform }}
-          framework: 'netcoreapp3.1'
-          architecture: ''
-          buildConfiguration: $(Configuration)
-      # Windows .NET Core x86 Tests
-      - template: ../job_templates/test_drawing_libraries.yml
-        parameters:
-          name: UnitTest${{ parameters.OSPlatform }}netcorex86
-          OSPlatform: ${{ parameters.OSPlatform }}
-          framework: 'netcoreapp3.1'
-          architecture: '.x86'
-          buildConfiguration: $(Configuration)
-      # Windows .NET 6.0 x86 Tests
-      - template: ../job_templates/test_drawing_libraries.yml
-        parameters:
-          name: UnitTest${{ parameters.OSPlatform }}net60x86
-          OSPlatform: ${{ parameters.OSPlatform }}
-          framework: 'net60'
-          architecture: '.x86'
-          buildConfiguration: $(Configuration)
-      # Windows .NET 7.0 x86 Tests
-      - template: ../job_templates/test_drawing_libraries.yml
-        parameters:
-          name: UnitTest${{ parameters.OSPlatform }}net70x86
-          OSPlatform: ${{ parameters.OSPlatform }}
-          framework: 'net70'
-          architecture: '.x86'
-          buildConfiguration: $(Configuration)
-    # .NET 5.0 Tests
+    # .NET 8.0 Tests
     - template: ../job_templates/test_drawing_libraries.yml
       parameters:
-        name: UnitTest${{ parameters.OSPlatform }}net50
+        name: UnitTest${{ parameters.OSPlatform }}net80
         OSPlatform: ${{ parameters.OSPlatform }}
-        framework: 'net50'
-        architecture: ''
-        buildConfiguration: $(Configuration)
-    # .NET 6.0 x64 Tests
-    - template: ../job_templates/test_drawing_libraries.yml
-      parameters:
-        name: UnitTest${{ parameters.OSPlatform }}net60
-        OSPlatform: ${{ parameters.OSPlatform }}
-        framework: 'net60'
-        architecture: ''
-        buildConfiguration: $(Configuration)
-    # .NET 7.0 x64 Tests
-    - template: ../job_templates/test_drawing_libraries.yml
-      parameters:
-        name: UnitTest${{ parameters.OSPlatform }}net70
-        OSPlatform: ${{ parameters.OSPlatform }}
-        framework: 'net70'
+        framework: 'net80'
         architecture: ''
         buildConfiguration: $(Configuration)

--- a/IronSoftware.Drawing/IronSoftware.Drawing.Common.Tests/IronSoftware.Drawing.Common.Tests.csproj
+++ b/IronSoftware.Drawing/IronSoftware.Drawing.Common.Tests/IronSoftware.Drawing.Common.Tests.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
 	<PropertyGroup>
-		<TargetFrameworks>net472;netcoreapp3.1;net50;net60;net70</TargetFrameworks>
+		<TargetFrameworks>net472;net80</TargetFrameworks>
 		<LangVersion>latest</LangVersion>
 		<CheckEolTargetFramework>false</CheckEolTargetFramework>
 		<IsPackable>false</IsPackable>

--- a/IronSoftware.Drawing/IronSoftware.Drawing.Common/IronSoftware.Drawing.Common.csproj
+++ b/IronSoftware.Drawing/IronSoftware.Drawing.Common/IronSoftware.Drawing.Common.csproj
@@ -12,7 +12,7 @@
 		<NoWarn>CS8002</NoWarn>
 		<Platforms>AnyCPU</Platforms>
 		<SignAssembly>true</SignAssembly>
-		<TargetFrameworks>netstandard2.0;netstandard2.1;net60</TargetFrameworks>
+		<TargetFrameworks>netstandard2.0;net60</TargetFrameworks>
 		<TransformOnBuild>true</TransformOnBuild>
 	</PropertyGroup>
 


### PR DESCRIPTION
### Cleanup .NET Framework Targets
- Remove netstandard2.1 build (it wasn't being included in the NuGet package, anyway)
- Only test net462/net80 (part of a broader effort to combine tests)

### Type of change
- [ ] 🐛 Bug fix (non-breaking change which fixes an issue)
- [ ] ✨ New feature (non-breaking change which adds functionality)
- [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] 🏗️ Internal/structural update (non-breaking change that improves code quality, organization, or performance)
- [ ] 📚 This change requires a documentation update
- [ ] 🚀 DevOps build chain modification for release
- [ ] 🤖 DevOps build chain modification for CI