### PR TITLE
[DW-27] Update SixLabour.ImageSharp due to vulnerability report

### DIFF
--- a/IronSoftware.Drawing/IronSoftware.Drawing.Common/IronSoftware.Drawing.Common.csproj
+++ b/IronSoftware.Drawing/IronSoftware.Drawing.Common/IronSoftware.Drawing.Common.csproj
@@ -41,7 +41,7 @@
 		</When>
 		<Otherwise>
 			<ItemGroup>
-				<PackageReference Include="SixLabors.ImageSharp" Version="2.1.8" />
+				<PackageReference Include="SixLabors.ImageSharp" Version="2.1.9" />
 				<PackageReference Include="SixLabors.ImageSharp.Drawing" Version="1.0.0" />
 			</ItemGroup>
 		</Otherwise>

--- a/NuGet/IronSoftware.Drawing.nuspec
+++ b/NuGet/IronSoftware.Drawing.nuspec
@@ -46,7 +46,7 @@ For general support and technical inquiries, please email us at: support@ironsof
 		<dependencies>
 			<group targetFramework="netstandard2.0">
 				<dependency id="IronSoftware.Common" version="2024.9.27" />
-				<dependency id="SixLabors.ImageSharp" version="2.1.8" />
+				<dependency id="SixLabors.ImageSharp" version="2.1.9" />
 				<dependency id="SixLabors.ImageSharp.Drawing" version="1.0.0" />
 				<dependency id="BitMiracle.LibTiff.NET" version="2.4.649" />
 				<dependency id="System.Memory" version="4.5.5" />
@@ -60,7 +60,7 @@ For general support and technical inquiries, please email us at: support@ironsof
 			</group>
 			<group targetFramework="MonoAndroid10.0">
 				<dependency id="IronSoftware.Common" version="2024.9.27" />
-				<dependency id="SixLabors.ImageSharp" version="2.1.8" />
+				<dependency id="SixLabors.ImageSharp" version="2.1.9" />
 				<dependency id="SixLabors.ImageSharp.Drawing" version="1.0.0" />
 				<dependency id="BitMiracle.LibTiff.NET" version="2.4.649" />
 				<dependency id="System.Memory" version="4.5.5" />


### PR DESCRIPTION
### Update SixLabour.ImageSharp due to vulnerability report

### Description
Upgrade SixLabour.ImageSharp to the version 2.1.9 for .netstandard 2.0 dependencies from this report: https://github.com/advisories/GHSA-63p8-c4ww-9cg7

Fixes #[DW-27](https://ironsoftware.atlassian.net/browse/DW-27)

### Type of change
Please select the relevant option by placing an 'x' inside the brackets, like this: [x].

- [ ] 🐛 Bug fix (non-breaking change which fixes an issue)
- [ ] ✨ New feature (non-breaking change which adds functionality)
- [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] 🏗️ Internal/structural update (non-breaking change that improves code quality, organization, or performance)
- [ ] 📚 This change requires a documentation update
- [ ] 🚀 DevOps build chain modification for release
- [ ] 🤖 DevOps build chain modification for CI

### How Has This Been Tested?
-

### Checklist:
Please run through the checklist as much as possible and mark the items completed by placing an 'x' inside the brackets, like this: [x].

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] I have successfully run all unit tests on Windows
- [x] I have successfully run all unit tests on Linux

### Additional Context
-


[DW-27]: https://ironsoftware.atlassian.net/browse/DW-27?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ