### PR TITLE
[DW-29] stop using CloneAs in GetPixelColor

### DIFF
--- a/IronSoftware.Drawing/IronSoftware.Drawing.Common.Tests/UnitTests/AnyBitmapFunctionality.cs
+++ b/IronSoftware.Drawing/IronSoftware.Drawing.Common.Tests/UnitTests/AnyBitmapFunctionality.cs
@@ -297,6 +297,36 @@ namespace IronSoftware.Drawing.Common.Tests.UnitTests
         }
 
         [FactWithAutomaticDisplayName]
+        public void AnyBitmap_GetPixel_should_not_throw_OutOfMemoryException()
+        {
+            //Should not throw exception
+            //previously GetPixel always called CloneAs() which resulted to OutOfMemoryException
+            string imagePath = GetRelativeFilePath("google_large_1500dpi.bmp");
+            using Image<Rgb24> formatRgb24 = Image.Load<Rgb24>(imagePath);
+            using Image<Abgr32> formatAbgr32 = Image.Load<Abgr32>(imagePath);
+            using Image<Argb32> formatArgb32 = Image.Load<Argb32>(imagePath);
+            using Image<Bgr24> formatBgr24 = Image.Load<Bgr24>(imagePath);
+            using Image<Bgra32> formatBgra32 = Image.Load<Bgra32>(imagePath);
+
+            Image[] images = { formatRgb24, formatAbgr32, formatArgb32, formatBgr24, formatBgra32 };
+
+            foreach (Image image in images)
+            {
+                AnyBitmap bitmap = (AnyBitmap)image;
+
+                int hash = 0;
+                for (int y = 0; y < bitmap.Height; y += 8)
+                {
+                    for (int x = 0; x < bitmap.Width; x += 8)
+                    {
+                        var pixel = bitmap.GetPixel(x, y);
+                        hash += pixel.ToArgb();
+                    }
+                }
+            }
+        }
+
+        [FactWithAutomaticDisplayName]
         public void Clone_AnyBitmap()
         {
             string imagePath = GetRelativeFilePath("van-gogh-starry-night-vincent-van-gogh.jpg");

--- a/IronSoftware.Drawing/IronSoftware.Drawing.Common/AnyBitmap.cs
+++ b/IronSoftware.Drawing/IronSoftware.Drawing.Common/AnyBitmap.cs
@@ -2545,29 +2545,36 @@ namespace IronSoftware.Drawing
 
         private Color GetPixelColor(int x, int y)
         {
-            if (Image is Image<Rgb24>)
+            switch (Image)
             {
-                return (Color)Image.CloneAs<Rgb24>()[x, y];
-            }
-            else if (Image is Image<Abgr32>)
-            {
-                return (Color)Image.CloneAs<Abgr32>()[x, y];
-            }
-            else if (Image is Image<Argb32>)
-            {
-                return (Color)Image.CloneAs<Argb32>()[x, y];
-            }
-            else if (Image is Image<Bgr24>)
-            {
-                return (Color)Image.CloneAs<Bgr24>()[x, y];
-            }
-            else if (Image is Image<Bgra32>)
-            {
-                return (Color)Image.CloneAs<Bgra32>()[x, y];
-            }
-            else
-            {
-                return (Color)Image.CloneAs<Rgba32>()[x, y];
+                case Image<Rgba32> imageAsFormat:
+                    return imageAsFormat[x, y];
+                case Image<Rgb24> imageAsFormat:
+                    return imageAsFormat[x, y];
+                case Image<Abgr32> imageAsFormat:
+                    return imageAsFormat[x, y];
+                case Image<Argb32> imageAsFormat:
+                    return imageAsFormat[x, y];
+                case Image<Bgr24> imageAsFormat:
+                    return imageAsFormat[x, y];
+                case Image<Bgra32> imageAsFormat:
+                    return imageAsFormat[x, y];
+                case Image<Rgb48> imageAsFormat:
+                    return imageAsFormat[x, y];
+                case Image<Rgba64> imageAsFormat:
+                    return imageAsFormat[x, y];
+                default:
+                    //Fallback
+
+                    //We didn't have Converter to IronSoftware.Drawing.Color for other pixel format
+                    //A8, L8, L16, La16, Bgr565, Bgra4444, RgbaVector
+
+                    //CloneAs() is expensive!
+                    //Can throw out of memory exception, when this fucntion get called too much
+                    using (Image<Rgb24> converted = Image.CloneAs<Rgb24>())
+                    {
+                        return converted[x, y];
+                    }
             }
         }
 


### PR DESCRIPTION
### Title
Fix Out of memory exception when call GetPixel

### Description

- Stop using CloneAs in GetPixelColor (its create a whole new image in memory)

Fixes 
[DW-29](https://ironsoftware.atlassian.net/browse/DW-29)

### Type of change
Please select the relevant option by placing an 'x' inside the brackets, like this: [x].

- [x] 🐛 Bug fix (non-breaking change which fixes an issue)
- [ ] ✨ New feature (non-breaking change which adds functionality)
- [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] 🏗️ Internal/structural update (non-breaking change that improves code quality, organization, or performance)
- [ ] 📚 This change requires a documentation update
- [ ] 🚀 DevOps build chain modification for release
- [ ] 🤖 DevOps build chain modification for CI

### How Has This Been Tested?
Added unit tests

### Checklist:
Please run through the checklist as much as possible and mark the items completed by placing an 'x' inside the brackets, like this: [x].

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [x] I have successfully run all unit tests on Windows
- [ ] I have successfully run all unit tests on Linux

### Additional Context
Add any other context, screenshots, or information about the pull request here.


[DW-29]: https://ironsoftware.atlassian.net/browse/DW-29?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ