### PR TITLE
remove conflicting method

### DIFF
--- a/IronSoftware.Drawing/IronSoftware.Drawing.Common.Tests/UnitTests/AnyBitmapFunctionality.cs
+++ b/IronSoftware.Drawing/IronSoftware.Drawing.Common.Tests/UnitTests/AnyBitmapFunctionality.cs
@@ -331,7 +331,7 @@ namespace IronSoftware.Drawing.Common.Tests.UnitTests
         {
             string imagePath = GetRelativeFilePath("van-gogh-starry-night-vincent-van-gogh.jpg");
             var anyBitmap = AnyBitmap.FromFile(imagePath);
-            AnyBitmap clonedAnyBitmap = anyBitmap.Clone();
+            AnyBitmap clonedAnyBitmap = anyBitmap.Clone() as AnyBitmap;
 
             anyBitmap.SaveAs("expected.png");
             clonedAnyBitmap.SaveAs("result.png");

--- a/IronSoftware.Drawing/IronSoftware.Drawing.Common/AnyBitmap.cs
+++ b/IronSoftware.Drawing/IronSoftware.Drawing.Common/AnyBitmap.cs
@@ -135,7 +135,7 @@ namespace IronSoftware.Drawing
         /// Code Example</a></para>
         /// </summary>
         /// <returns></returns>
-        public AnyBitmap Clone()
+        public object Clone()
         {
             return new AnyBitmap(Binary);
         }
@@ -735,7 +735,7 @@ namespace IronSoftware.Drawing
                 }
                 else
                 {
-                    return new List<AnyBitmap>() { Clone() };
+                    return new List<AnyBitmap>() { Clone() as AnyBitmap};
                 }
             }
         }
@@ -2661,11 +2661,6 @@ namespace IronSoftware.Drawing
             await stream.CopyToAsync(memoryStream);
             memoryStream.Position = 0;
             return memoryStream;
-        }
-
-        object ICloneable.Clone()
-        {
-            return this.Clone();
         }
 
         #endregion


### PR DESCRIPTION
I'm receiving an error when trying to call Clone():

>     System.TypeLoadException : Method 'Clone' in type 'IronSoftware.Drawing.AnyBitmap' from assembly 'IronSoftware.Drawing.Common, Version=2025.3.0.2, Culture=neutral, PublicKeyToken=8d7e55c97b3e9835' does not have an implementation.


I know it's a breaking change, but can just change Clone() to return `object`