### PR TITLE
IronDrawing Release Preparation [2025.3]

### DIFF
--- a/IronSoftware.Drawing/IronSoftware.Drawing.Common/IronSoftware.Drawing.Common.csproj
+++ b/IronSoftware.Drawing/IronSoftware.Drawing.Common/IronSoftware.Drawing.Common.csproj
@@ -35,13 +35,13 @@
 	<Choose>
 		<When Condition="'$(TargetFramework)' == 'net60'">
 			<ItemGroup>
-				<PackageReference Include="SixLabors.ImageSharp" Version="3.1.5" />
-				<PackageReference Include="SixLabors.ImageSharp.Drawing" Version="2.1.4" />
+				<PackageReference Include="SixLabors.ImageSharp" Version="3.1.7" />
+				<PackageReference Include="SixLabors.ImageSharp.Drawing" Version="2.1.5" />
 			</ItemGroup>
 		</When>
 		<Otherwise>
 			<ItemGroup>
-				<PackageReference Include="SixLabors.ImageSharp" Version="2.1.9" />
+				<PackageReference Include="SixLabors.ImageSharp" Version="2.1.10" />
 				<PackageReference Include="SixLabors.ImageSharp.Drawing" Version="1.0.0" />
 			</ItemGroup>
 		</Otherwise>

--- a/NuGet/IronSoftware.Drawing.nuspec
+++ b/NuGet/IronSoftware.Drawing.nuspec
@@ -39,8 +39,9 @@ Supports:
 
 For general support and technical inquiries, please email us at: support@ironsoftware.com</description>
 		<summary>IronSoftware.System.Drawing is an open-source solution for .NET developers to replace System.Drawing.Common with a universal and flexible library.</summary>
-		<releaseNotes>- Internal improvement of the library functionality</releaseNotes>
-		<copyright>Copyright © Iron Software 2022-2024</copyright>
+		<releaseNotes>- Fixes incorrect HorizontalResolution and VerticalResolution of AnyBitmap images.
+		- Improves library's internal functionality and performance.</releaseNotes>
+		<copyright>Copyright © Iron Software 2022-2025</copyright>
 		<tags>Images, Bitmap, SkiaSharp, SixLabors, BitMiracle, Maui, SVG, TIFF, TIF, GIF, JPEG, PNG, Color, Rectangle, Drawing, C#, VB.NET, ASPX, create, render, generate, standard, netstandard2.0, core, netcore</tags>
 		<repository type="git" url="https://github.com/iron-software/IronSoftware.Drawing.Common" commit="$commit$" />
 		<dependencies>
@@ -57,16 +58,6 @@ For general support and technical inquiries, please email us at: support@ironsof
 				<dependency id="SixLabors.ImageSharp.Drawing" version="2.1.4" />
 				<dependency id="BitMiracle.LibTiff.NET" version="2.4.649" />
 				<dependency id="System.Memory" version="4.5.5" />
-			</group>
-			<group targetFramework="MonoAndroid10.0">
-				<dependency id="IronSoftware.Drawing.Abstractions" version="2025.2.6" />
-				<dependency id="SixLabors.ImageSharp" version="2.1.9" />
-				<dependency id="SixLabors.ImageSharp.Drawing" version="1.0.0" />
-				<dependency id="BitMiracle.LibTiff.NET" version="2.4.649" />
-				<dependency id="System.Memory" version="4.5.5" />
-				<dependency id="Microsoft.Maui.Graphics" version="7.0.92" />
-				<dependency id="SkiaSharp" version="2.88.7" />
-				<dependency id="SkiaSharp.Svg" version="1.60.0" />
 			</group>
 		</dependencies>
 	</metadata>

--- a/NuGet/IronSoftware.Drawing.nuspec
+++ b/NuGet/IronSoftware.Drawing.nuspec
@@ -47,15 +47,15 @@ For general support and technical inquiries, please email us at: support@ironsof
 		<dependencies>
 			<group targetFramework="netstandard2.0">
 				<dependency id="IronSoftware.Drawing.Abstractions" version="2025.2.6" />
-				<dependency id="SixLabors.ImageSharp" version="2.1.9" />
+				<dependency id="SixLabors.ImageSharp" version="2.1.10" />
 				<dependency id="SixLabors.ImageSharp.Drawing" version="1.0.0" />
 				<dependency id="BitMiracle.LibTiff.NET" version="2.4.649" />
 				<dependency id="System.Memory" version="4.5.5" />
 			</group>
 			<group targetFramework="net60">
 				<dependency id="IronSoftware.Drawing.Abstractions" version="2025.2.6" />
-				<dependency id="SixLabors.ImageSharp" version="3.1.5" />
-				<dependency id="SixLabors.ImageSharp.Drawing" version="2.1.4" />
+				<dependency id="SixLabors.ImageSharp" version="3.1.7" />
+				<dependency id="SixLabors.ImageSharp.Drawing" version="2.1.5" />
 				<dependency id="BitMiracle.LibTiff.NET" version="2.4.649" />
 				<dependency id="System.Memory" version="4.5.5" />
 			</group>


### PR DESCRIPTION
### Change Lists
- Updates IronSoftware.Abstractions to v2025.2.6
- Remove MonoAndroid Target Framework
- Update release notes
- Update copyright year to 2025
