### PR TITLE
DW-33 Add preserveOriginalFormat bool while loading image

### DIFF
--- a/CI/job_templates/test_drawing_libraries.yml
+++ b/CI/job_templates/test_drawing_libraries.yml
@@ -20,7 +20,7 @@ jobs:
         buildType: 'current'
         artifactName: 'IronDrawingDataTests'
         targetPath: '$(Agent.BuildDirectory)/Data'
-    - ${{ if eq(parameters.OSPlatform, 'Ubuntu') || eq(parameters.OSPlatform, 'Linux') }}:
+    - ${{ if or(eq(parameters.OSPlatform, 'Ubuntu'), eq(parameters.OSPlatform, 'Linux')) }}:
       - task: Bash@3        
         displayName: 'Install GDI+ dependencies'
         inputs:

--- a/CI/job_templates/test_drawing_libraries.yml
+++ b/CI/job_templates/test_drawing_libraries.yml
@@ -20,6 +20,14 @@ jobs:
         buildType: 'current'
         artifactName: 'IronDrawingDataTests'
         targetPath: '$(Agent.BuildDirectory)/Data'
+    - ${{ if eq(parameters.OSPlatform, 'Ubuntu') }}:
+      - task: Bash@3        
+        displayName: 'Install GDI+ dependencies'
+        inputs:
+          targetType: 'inline'
+          script: |
+            sudo apt-get update
+            sudo apt-get install -y libgdiplus libc6-dev
     - ${{ if eq(parameters.framework, 'netcoreapp3.1') }}:
       - task: UseDotNet@2
         displayName: 'Install .Netcoreapp3.1 Core sdk'

--- a/CI/job_templates/test_drawing_libraries.yml
+++ b/CI/job_templates/test_drawing_libraries.yml
@@ -20,7 +20,7 @@ jobs:
         buildType: 'current'
         artifactName: 'IronDrawingDataTests'
         targetPath: '$(Agent.BuildDirectory)/Data'
-    - ${{ if eq(parameters.OSPlatform, 'Ubuntu') }}:
+    - ${{ if eq(parameters.OSPlatform, 'Ubuntu') || eq(parameters.OSPlatform, 'Linux') }}:
       - task: Bash@3        
         displayName: 'Install GDI+ dependencies'
         inputs:

--- a/IronSoftware.Drawing/IronSoftware.Drawing.Common.Tests/UnitTests/AnyBitmapFunctionality.cs
+++ b/IronSoftware.Drawing/IronSoftware.Drawing.Common.Tests/UnitTests/AnyBitmapFunctionality.cs
@@ -942,6 +942,26 @@ namespace IronSoftware.Drawing.Common.Tests.UnitTests
             bitmap.FrameCount.Should().Be(1);
         }
 
+        [TheoryWithAutomaticDisplayName]
+        [InlineData("24_bit.png")]
+        [InlineData("checkmark.jpg")]
+        [InlineData("DW-26 Jpg72Input.jpg")]
+        [InlineData("DW-26 Jpg300Input.jpg")]
+        [InlineData("mountainclimbers.jpg")]
+        public void LoadImage_SetPreserveOriginalFormat_ShouldReturnCorrectBitPerPixel(string imageFileName)
+        {
+            // Arrange
+            string imagePath = GetRelativeFilePath(imageFileName);
+
+            // Act
+            var preserve = new AnyBitmap(imagePath, true);
+            var notPreserve = new AnyBitmap(imagePath, false);
+
+            // Assert
+            Assert.Equal(24, preserve.BitsPerPixel);
+            Assert.Equal(32, notPreserve.BitsPerPixel);
+        }
+
 #if !NET7_0
         [FactWithAutomaticDisplayName]
         public void CastAnyBitmap_from_SixLabors()

--- a/IronSoftware.Drawing/IronSoftware.Drawing.Common/AnyBitmap.cs
+++ b/IronSoftware.Drawing/IronSoftware.Drawing.Common/AnyBitmap.cs
@@ -462,7 +462,7 @@ namespace IronSoftware.Drawing
         /// Create a new Bitmap from a a Byte Span.
         /// </summary>
         /// <param name="span">A Byte Span of image data in any common format.</param>
-        /// <param name="preserveOriginalFormat">Determine wheter load <see cref="SixLabors.ImageSharp.Image"/> as its original pixel format or Rgba32.
+        /// <param name="preserveOriginalFormat">Determine whether load <see cref="SixLabors.ImageSharp.Image"/> as its original pixel format or Rgba32.
         /// Default is true. Set to false to load as Rgba32.</param>
         public static AnyBitmap FromSpan(ReadOnlySpan<byte> span, bool preserveOriginalFormat = true)
         {
@@ -473,7 +473,7 @@ namespace IronSoftware.Drawing
         /// Create a new Bitmap from a a Byte Array.
         /// </summary>
         /// <param name="bytes">A ByteArray of image data in any common format.</param>
-        /// <param name="preserveOriginalFormat">Determine wheter load <see cref="SixLabors.ImageSharp.Image"/> as its original pixel format or Rgba32.
+        /// <param name="preserveOriginalFormat">Determine whether load <see cref="SixLabors.ImageSharp.Image"/> as its original pixel format or Rgba32.
         /// Default is true. Set to false to load as Rgba32.</param>
         public static AnyBitmap FromBytes(byte[] bytes, bool preserveOriginalFormat = true)
         {
@@ -484,7 +484,7 @@ namespace IronSoftware.Drawing
         /// Create a new Bitmap from a <see cref="Stream"/> (bytes).
         /// </summary>
         /// <param name="stream">A <see cref="Stream"/> of image data in any common format.</param> 
-        /// <param name="preserveOriginalFormat">Determine wheter load <see cref="SixLabors.ImageSharp.Image"/> as its original pixel format or Rgba32.
+        /// <param name="preserveOriginalFormat">Determine whether load <see cref="SixLabors.ImageSharp.Image"/> as its original pixel format or Rgba32.
         /// Default is true. Set to false to load as Rgba32.</param>
         /// <seealso cref="FromStream(Stream, bool)"/>
         /// <seealso cref="AnyBitmap"/>
@@ -497,7 +497,7 @@ namespace IronSoftware.Drawing
         /// Create a new Bitmap from a <see cref="Stream"/> (bytes).
         /// </summary>
         /// <param name="stream">A <see cref="Stream"/> of image data in any common format.</param>
-        /// <param name="preserveOriginalFormat">Determine wheter load <see cref="SixLabors.ImageSharp.Image"/> as its original pixel format or Rgba32.
+        /// <param name="preserveOriginalFormat">Determine whether load <see cref="SixLabors.ImageSharp.Image"/> as its original pixel format or Rgba32.
         /// Default is true. Set to false to load as Rgba32.</param>
         /// <seealso cref="FromStream(MemoryStream, bool)"/>
         /// <seealso cref="AnyBitmap"/>
@@ -510,7 +510,7 @@ namespace IronSoftware.Drawing
         /// Construct a new Bitmap from binary data (byte span).
         /// </summary>
         /// <param name="span">A byte span of image data in any common format.</param>
-        /// <param name="preserveOriginalFormat">Determine wheter load <see cref="SixLabors.ImageSharp.Image"/> as its original pixel format or Rgba32.
+        /// <param name="preserveOriginalFormat">Determine whether load <see cref="SixLabors.ImageSharp.Image"/> as its original pixel format or Rgba32.
         /// Default is true. Set to false to load as Rgba32.</param>
         /// <seealso cref="AnyBitmap"/>
         public AnyBitmap(ReadOnlySpan<byte> span, bool preserveOriginalFormat = true)
@@ -522,7 +522,7 @@ namespace IronSoftware.Drawing
         /// Construct a new Bitmap from binary data (bytes).
         /// </summary>
         /// <param name="bytes">A ByteArray of image data in any common format.</param>
-        /// <param name="preserveOriginalFormat">Determine wheter load <see cref="SixLabors.ImageSharp.Image"/> as its original pixel format or Rgba32.
+        /// <param name="preserveOriginalFormat">Determine whether load <see cref="SixLabors.ImageSharp.Image"/> as its original pixel format or Rgba32.
         /// Default is true. Set to false to load as Rgba32.</param>
         /// <seealso cref="FromBytes"/>
         /// <seealso cref="AnyBitmap"/>
@@ -535,7 +535,7 @@ namespace IronSoftware.Drawing
         /// Construct a new Bitmap from a <see cref="Stream"/> (bytes).
         /// </summary>
         /// <param name="stream">A <see cref="Stream"/> of image data in any common format.</param>
-        /// <param name="preserveOriginalFormat">Determine wheter load <see cref="SixLabors.ImageSharp.Image"/> as its original pixel format or Rgba32.
+        /// <param name="preserveOriginalFormat">Determine whether load <see cref="SixLabors.ImageSharp.Image"/> as its original pixel format or Rgba32.
         /// Default is true. Set to false to load as Rgba32.</param>
         /// <seealso cref="FromStream(Stream, bool)"/>
         /// <seealso cref="AnyBitmap"/>
@@ -548,7 +548,7 @@ namespace IronSoftware.Drawing
         /// Construct a new Bitmap from a <see cref="Stream"/> (bytes).
         /// </summary>
         /// <param name="stream">A <see cref="Stream"/> of image data in any common format.</param>
-        /// <param name="preserveOriginalFormat">Determine wheter load <see cref="SixLabors.ImageSharp.Image"/> as its original pixel format or Rgba32.
+        /// <param name="preserveOriginalFormat">Determine whether load <see cref="SixLabors.ImageSharp.Image"/> as its original pixel format or Rgba32.
         /// Default is true. Set to false to load as Rgba32.</param>
         /// <seealso cref="FromStream(MemoryStream, bool)"/>
         /// <seealso cref="AnyBitmap"/>
@@ -573,7 +573,7 @@ namespace IronSoftware.Drawing
         /// Construct a new Bitmap from a file.
         /// </summary>
         /// <param name="file">A fully qualified file path./</param>
-        /// <param name="preserveOriginalFormat">Determine wheter load <see cref="SixLabors.ImageSharp.Image"/> as its original pixel format or Rgba32.
+        /// <param name="preserveOriginalFormat">Determine whether load <see cref="SixLabors.ImageSharp.Image"/> as its original pixel format or Rgba32.
         /// Default is true. Set to false to load as Rgba32.</param>
         /// <seealso cref="FromFile"/>
         /// <seealso cref="AnyBitmap"/>
@@ -586,7 +586,7 @@ namespace IronSoftware.Drawing
         /// Construct a new Bitmap from a Uri
         /// </summary>
         /// <param name="uri">The uri of the image.</param>
-        /// <param name="preserveOriginalFormat">Determine wheter load <see cref="SixLabors.ImageSharp.Image"/> as its original pixel format or Rgba32.
+        /// <param name="preserveOriginalFormat">Determine whether load <see cref="SixLabors.ImageSharp.Image"/> as its original pixel format or Rgba32.
         /// Default is true. Set to false to load as Rgba32.</param>
         /// <seealso cref="FromUriAsync"/>
         /// <seealso cref="AnyBitmap"/>
@@ -618,7 +618,7 @@ namespace IronSoftware.Drawing
         /// Create a new Bitmap from a file.
         /// </summary>
         /// <param name="file">A fully qualified file path.</param>
-        /// <param name="preserveOriginalFormat">Determine wheter load <see cref="SixLabors.ImageSharp.Image"/> as its original pixel format or Rgba32.
+        /// <param name="preserveOriginalFormat">Determine whether load <see cref="SixLabors.ImageSharp.Image"/> as its original pixel format or Rgba32.
         /// Default is true. Set to false to load as Rgba32.</param>
         /// <seealso cref="FromFile"/>
         /// <seealso cref="AnyBitmap"/>
@@ -638,7 +638,7 @@ namespace IronSoftware.Drawing
         /// Construct a new Bitmap from a Uri
         /// </summary>
         /// <param name="uri">The uri of the image.</param>
-        /// <param name="preserveOriginalFormat">Determine wheter load <see cref="SixLabors.ImageSharp.Image"/> as its original pixel format or Rgba32.
+        /// <param name="preserveOriginalFormat">Determine whether load <see cref="SixLabors.ImageSharp.Image"/> as its original pixel format or Rgba32.
         /// Default is true. Set to false to load as Rgba32.</param>
         /// <returns></returns>
         /// <seealso cref="AnyBitmap"/>
@@ -661,7 +661,7 @@ namespace IronSoftware.Drawing
         /// Construct a new Bitmap from a Uri
         /// </summary>
         /// <param name="uri">The uri of the image.</param>
-        /// <param name="preserveOriginalFormat">Determine wheter load <see cref="SixLabors.ImageSharp.Image"/> as its original pixel format or Rgba32.
+        /// <param name="preserveOriginalFormat">Determine whether load <see cref="SixLabors.ImageSharp.Image"/> as its original pixel format or Rgba32.
         /// Default is true. Set to false to load as Rgba32.</param>
         /// <returns></returns>
         /// <seealso cref="AnyBitmap"/>
@@ -2049,12 +2049,12 @@ namespace IronSoftware.Drawing
                 else
                 {
                     Binary = bytes.ToArray();
-                    Image = Image.Load(bytes);
 
-                    if (!preserveOriginalFormat)
+                    if (preserveOriginalFormat)
+                        Image = Image.Load(bytes);
+                    else
                     {
-                        if (Image is not Image<Rgba32>)
-                            Image = Image.CloneAs<Rgba32>();
+                        Image = Image.Load<Rgba32>(bytes);
 
                         // .png image pre-processing
                         if (Format.Name == "PNG")

--- a/IronSoftware.Drawing/IronSoftware.Drawing.Common/AnyBitmap.cs
+++ b/IronSoftware.Drawing/IronSoftware.Drawing.Common/AnyBitmap.cs
@@ -2063,6 +2063,10 @@ namespace IronSoftware.Drawing
                             Image.Mutate(img => img.BackgroundColor(SixLabors.ImageSharp.Color.White));
                     }
 
+                    // Fix if the input image is auto-rotated; this issue is acknowledged by SixLabors.ImageSharp community
+                    // ref: https://github.com/SixLabors/ImageSharp/discussions/2685
+                    Image.Mutate(x => x.AutoOrient());
+
                     var resolutionUnit = this.Image.Metadata.ResolutionUnits;
                     var horizontal = this.Image.Metadata.HorizontalResolution;
                     var vertical = this.Image.Metadata.VerticalResolution;

--- a/IronSoftware.Drawing/IronSoftware.Drawing.Common/AnyBitmap.cs
+++ b/IronSoftware.Drawing/IronSoftware.Drawing.Common/AnyBitmap.cs
@@ -462,87 +462,99 @@ namespace IronSoftware.Drawing
         /// Create a new Bitmap from a a Byte Span.
         /// </summary>
         /// <param name="span">A Byte Span of image data in any common format.</param>
-        public static AnyBitmap FromSpan(ReadOnlySpan<byte> span)
+        /// <param name="preserveOriginalFormat">Determine wheter load <see cref="SixLabors.ImageSharp.Image"/> as its original pixel format or Rgba32.
+        /// Default is true. Set to false to load as Rgba32.</param>
+        public static AnyBitmap FromSpan(ReadOnlySpan<byte> span, bool preserveOriginalFormat = true)
         {
-            return new AnyBitmap(span);
+            return new AnyBitmap(span, preserveOriginalFormat);
         }
 
         /// <summary>
         /// Create a new Bitmap from a a Byte Array.
         /// </summary>
         /// <param name="bytes">A ByteArray of image data in any common format.</param>
-        public static AnyBitmap FromBytes(byte[] bytes)
+        /// <param name="preserveOriginalFormat">Determine wheter load <see cref="SixLabors.ImageSharp.Image"/> as its original pixel format or Rgba32.
+        /// Default is true. Set to false to load as Rgba32.</param>
+        public static AnyBitmap FromBytes(byte[] bytes, bool preserveOriginalFormat = true)
         {
-            return new AnyBitmap(bytes);
+            return new AnyBitmap(bytes, preserveOriginalFormat);
         }
 
         /// <summary>
         /// Create a new Bitmap from a <see cref="Stream"/> (bytes).
         /// </summary>
-        /// <param name="stream">A <see cref="Stream"/> of image data in any 
-        /// common format.</param>
-        /// <seealso cref="FromStream(Stream)"/>
+        /// <param name="stream">A <see cref="Stream"/> of image data in any common format.</param> 
+        /// <param name="preserveOriginalFormat">Determine wheter load <see cref="SixLabors.ImageSharp.Image"/> as its original pixel format or Rgba32.
+        /// Default is true. Set to false to load as Rgba32.</param>
+        /// <seealso cref="FromStream(Stream, bool)"/>
         /// <seealso cref="AnyBitmap"/>
-        public static AnyBitmap FromStream(MemoryStream stream)
+        public static AnyBitmap FromStream(MemoryStream stream, bool preserveOriginalFormat = true)
         {
-            return new AnyBitmap(stream);
+            return new AnyBitmap(stream, preserveOriginalFormat);
         }
 
         /// <summary>
         /// Create a new Bitmap from a <see cref="Stream"/> (bytes).
         /// </summary>
-        /// <param name="stream">A <see cref="Stream"/> of image data in any 
-        /// common format.</param>
-        /// <seealso cref="FromStream(MemoryStream)"/>
+        /// <param name="stream">A <see cref="Stream"/> of image data in any common format.</param>
+        /// <param name="preserveOriginalFormat">Determine wheter load <see cref="SixLabors.ImageSharp.Image"/> as its original pixel format or Rgba32.
+        /// Default is true. Set to false to load as Rgba32.</param>
+        /// <seealso cref="FromStream(MemoryStream, bool)"/>
         /// <seealso cref="AnyBitmap"/>
-        public static AnyBitmap FromStream(Stream stream)
+        public static AnyBitmap FromStream(Stream stream, bool preserveOriginalFormat = true)
         {
-            return new AnyBitmap(stream);
+            return new AnyBitmap(stream, preserveOriginalFormat);
         }
 
         /// <summary>
         /// Construct a new Bitmap from binary data (byte span).
         /// </summary>
         /// <param name="span">A byte span of image data in any common format.</param>
+        /// <param name="preserveOriginalFormat">Determine wheter load <see cref="SixLabors.ImageSharp.Image"/> as its original pixel format or Rgba32.
+        /// Default is true. Set to false to load as Rgba32.</param>
         /// <seealso cref="AnyBitmap"/>
-        public AnyBitmap(ReadOnlySpan<byte> span)
+        public AnyBitmap(ReadOnlySpan<byte> span, bool preserveOriginalFormat = true)
         {
-            LoadImage(span);
+            LoadImage(span, preserveOriginalFormat);
         }
 
         /// <summary>
         /// Construct a new Bitmap from binary data (bytes).
         /// </summary>
         /// <param name="bytes">A ByteArray of image data in any common format.</param>
+        /// <param name="preserveOriginalFormat">Determine wheter load <see cref="SixLabors.ImageSharp.Image"/> as its original pixel format or Rgba32.
+        /// Default is true. Set to false to load as Rgba32.</param>
         /// <seealso cref="FromBytes"/>
         /// <seealso cref="AnyBitmap"/>
-        public AnyBitmap(byte[] bytes)
+        public AnyBitmap(byte[] bytes, bool preserveOriginalFormat = true)
         {
-            LoadImage(bytes);
+            LoadImage(bytes, preserveOriginalFormat);
         }
 
         /// <summary>
         /// Construct a new Bitmap from a <see cref="Stream"/> (bytes).
         /// </summary>
-        /// <param name="stream">A <see cref="Stream"/> of image data in any 
-        /// common format.</param>
-        /// <seealso cref="FromStream(Stream)"/>
+        /// <param name="stream">A <see cref="Stream"/> of image data in any common format.</param>
+        /// <param name="preserveOriginalFormat">Determine wheter load <see cref="SixLabors.ImageSharp.Image"/> as its original pixel format or Rgba32.
+        /// Default is true. Set to false to load as Rgba32.</param>
+        /// <seealso cref="FromStream(Stream, bool)"/>
         /// <seealso cref="AnyBitmap"/>
-        public AnyBitmap(MemoryStream stream)
+        public AnyBitmap(MemoryStream stream, bool preserveOriginalFormat = true)
         {
-            LoadImage(stream.ToArray());
+            LoadImage(stream.ToArray(), preserveOriginalFormat);
         }
 
         /// <summary>
         /// Construct a new Bitmap from a <see cref="Stream"/> (bytes).
         /// </summary>
-        /// <param name="stream">A <see cref="Stream"/> of image data in any 
-        /// common format.</param>
-        /// <seealso cref="FromStream(MemoryStream)"/>
+        /// <param name="stream">A <see cref="Stream"/> of image data in any common format.</param>
+        /// <param name="preserveOriginalFormat">Determine wheter load <see cref="SixLabors.ImageSharp.Image"/> as its original pixel format or Rgba32.
+        /// Default is true. Set to false to load as Rgba32.</param>
+        /// <seealso cref="FromStream(MemoryStream, bool)"/>
         /// <seealso cref="AnyBitmap"/>
-        public AnyBitmap(Stream stream)
+        public AnyBitmap(Stream stream, bool preserveOriginalFormat = true)
         {
-            LoadImage(stream);
+            LoadImage(stream, preserveOriginalFormat);
         }
 
         /// <summary>
@@ -561,25 +573,29 @@ namespace IronSoftware.Drawing
         /// Construct a new Bitmap from a file.
         /// </summary>
         /// <param name="file">A fully qualified file path./</param>
+        /// <param name="preserveOriginalFormat">Determine wheter load <see cref="SixLabors.ImageSharp.Image"/> as its original pixel format or Rgba32.
+        /// Default is true. Set to false to load as Rgba32.</param>
         /// <seealso cref="FromFile"/>
         /// <seealso cref="AnyBitmap"/>
-        public AnyBitmap(string file)
+        public AnyBitmap(string file, bool preserveOriginalFormat = true)
         {
-            LoadImage(File.ReadAllBytes(file));
+            LoadImage(File.ReadAllBytes(file), preserveOriginalFormat);
         }
 
         /// <summary>
         /// Construct a new Bitmap from a Uri
         /// </summary>
         /// <param name="uri">The uri of the image.</param>
+        /// <param name="preserveOriginalFormat">Determine wheter load <see cref="SixLabors.ImageSharp.Image"/> as its original pixel format or Rgba32.
+        /// Default is true. Set to false to load as Rgba32.</param>
         /// <seealso cref="FromUriAsync"/>
         /// <seealso cref="AnyBitmap"/>
-        public AnyBitmap(Uri uri)
+        public AnyBitmap(Uri uri, bool preserveOriginalFormat = true)
         {
             try
             {
                 using Stream stream = LoadUriAsync(uri).GetAwaiter().GetResult();
-                LoadImage(stream);
+                LoadImage(stream, preserveOriginalFormat);
             }
             catch (Exception e)
             {
@@ -602,17 +618,19 @@ namespace IronSoftware.Drawing
         /// Create a new Bitmap from a file.
         /// </summary>
         /// <param name="file">A fully qualified file path.</param>
+        /// <param name="preserveOriginalFormat">Determine wheter load <see cref="SixLabors.ImageSharp.Image"/> as its original pixel format or Rgba32.
+        /// Default is true. Set to false to load as Rgba32.</param>
         /// <seealso cref="FromFile"/>
         /// <seealso cref="AnyBitmap"/>
-        public static AnyBitmap FromFile(string file)
+        public static AnyBitmap FromFile(string file, bool preserveOriginalFormat = true)
         {
             if (file.ToLower().EndsWith(".svg"))
             {
-                return LoadSVGImage(file);
+                return LoadSVGImage(file, preserveOriginalFormat);
             }
             else
             {
-                return new AnyBitmap(file);
+                return new AnyBitmap(file, preserveOriginalFormat);
             }
         }
 
@@ -620,16 +638,18 @@ namespace IronSoftware.Drawing
         /// Construct a new Bitmap from a Uri
         /// </summary>
         /// <param name="uri">The uri of the image.</param>
+        /// <param name="preserveOriginalFormat">Determine wheter load <see cref="SixLabors.ImageSharp.Image"/> as its original pixel format or Rgba32.
+        /// Default is true. Set to false to load as Rgba32.</param>
         /// <returns></returns>
         /// <seealso cref="AnyBitmap"/>
         /// <seealso cref="FromUri"/>
         /// <seealso cref="FromUriAsync"/>
-        public static async Task<AnyBitmap> FromUriAsync(Uri uri)
+        public static async Task<AnyBitmap> FromUriAsync(Uri uri, bool preserveOriginalFormat = true)
         {
             try
             {
                 using Stream stream = await LoadUriAsync(uri);
-                return new AnyBitmap(stream);
+                return new AnyBitmap(stream, preserveOriginalFormat);
             }
             catch (Exception e)
             {
@@ -641,13 +661,15 @@ namespace IronSoftware.Drawing
         /// Construct a new Bitmap from a Uri
         /// </summary>
         /// <param name="uri">The uri of the image.</param>
+        /// <param name="preserveOriginalFormat">Determine wheter load <see cref="SixLabors.ImageSharp.Image"/> as its original pixel format or Rgba32.
+        /// Default is true. Set to false to load as Rgba32.</param>
         /// <returns></returns>
         /// <seealso cref="AnyBitmap"/>
         /// <seealso cref="FromUriAsync"/>
 #if NET6_0_OR_GREATER
         [Obsolete("FromUri(Uri) is obsolete for net60 or greater because it uses WebClient which is obsolete. Consider using FromUriAsync(Uri) method.")]
 #endif
-        public static AnyBitmap FromUri(Uri uri)
+        public static AnyBitmap FromUri(Uri uri, bool preserveOriginalFormat = true)
         {
             try
             {
@@ -2017,19 +2039,28 @@ namespace IronSoftware.Drawing
             Binary = stream.ToArray();
         }
         
-        private void LoadImage(ReadOnlySpan<byte> bytes)
+        private void LoadImage(ReadOnlySpan<byte> bytes, bool preserveOriginalFormat)
         {
             Format = Image.DetectFormat(bytes);
             try
             {
                 if (Format is TiffFormat)
                     OpenTiffToImageSharp(bytes);
-
                 else
                 {
                     Binary = bytes.ToArray();
                     Image = Image.Load(bytes);
-                    
+
+                    if (!preserveOriginalFormat)
+                    {
+                        if (Image is not Image<Rgba32>)
+                            Image = Image.CloneAs<Rgba32>();
+
+                        // .png image pre-processing
+                        if (Format.Name == "PNG")
+                            Image.Mutate(img => img.BackgroundColor(SixLabors.ImageSharp.Color.White));
+                    }
+
                     var resolutionUnit = this.Image.Metadata.ResolutionUnits;
                     var horizontal = this.Image.Metadata.HorizontalResolution;
                     var vertical = this.Image.Metadata.VerticalResolution;
@@ -2067,7 +2098,7 @@ namespace IronSoftware.Drawing
             }
         }
 
-        private void LoadImage(Stream stream)
+        private void LoadImage(Stream stream, bool preserveOriginalFormat)
         {
             byte[] buffer = new byte[16 * 1024];
             using MemoryStream ms = new();
@@ -2077,17 +2108,17 @@ namespace IronSoftware.Drawing
                 ms.Write(buffer, 0, read);
             }
 
-            LoadImage(ms.ToArray());
+            LoadImage(ms.ToArray(), preserveOriginalFormat);
         }
 
-        private static AnyBitmap LoadSVGImage(string file)
+        private static AnyBitmap LoadSVGImage(string file, bool preserveOriginalFormat)
         {
             try
 
             {
                 return new AnyBitmap(
                     DecodeSVG(file).Encode(SKEncodedImageFormat.Png, 100)
-                    .ToArray());
+                    .ToArray(), preserveOriginalFormat);
             }
             catch (DllNotFoundException e)
             {

--- a/IronSoftware.Drawing/IronSoftware.Drawing.Common/AnyBitmap.cs
+++ b/IronSoftware.Drawing/IronSoftware.Drawing.Common/AnyBitmap.cs
@@ -52,6 +52,7 @@ namespace IronSoftware.Drawing
         private byte[] Binary { get; set; }
         private IImageFormat Format { get; set; }
         private TiffCompression TiffCompression { get; set; } = TiffCompression.Lzw;
+        private bool PreserveOriginalFormat { get; set; } = true;
 
         /// <summary>
         /// Width of the image.
@@ -138,7 +139,7 @@ namespace IronSoftware.Drawing
         /// <returns></returns>
         public AnyBitmap Clone()
         {
-            return new AnyBitmap(Binary);
+            return new AnyBitmap(Binary, PreserveOriginalFormat);
         }
 
         /// <summary>
@@ -2054,6 +2055,7 @@ namespace IronSoftware.Drawing
                         Image = Image.Load(bytes);
                     else
                     {
+                        PreserveOriginalFormat = preserveOriginalFormat;
                         Image = Image.Load<Rgba32>(bytes);
 
                         // .png image pre-processing

--- a/IronSoftware.Drawing/IronSoftware.Drawing.Common/AnyBitmap.cs
+++ b/IronSoftware.Drawing/IronSoftware.Drawing.Common/AnyBitmap.cs
@@ -2233,6 +2233,21 @@ namespace IronSoftware.Drawing
             }
         }
 
+        /// <summary>
+        /// Disable warning message written to console by BitMiracle.LibTiff.NET.
+        /// </summary>
+        private class DisableErrorHandler : TiffErrorHandler
+        {
+            public override void WarningHandler(Tiff tif, string method, string format, params object[] args)
+            {
+                // do nothing, ie, do not write warnings to console
+            }
+            public override void WarningHandlerExt(Tiff tif, object clientData, string method, string format, params object[] args)
+            {
+                // do nothing ie, do not write warnings to console
+            }
+        }
+
         private void OpenTiffToImageSharp(ReadOnlySpan<byte> bytes)
         {
             try
@@ -2245,6 +2260,9 @@ namespace IronSoftware.Drawing
 
                 // create a memory stream out of them
                 using MemoryStream tiffStream = new(bytes.ToArray());
+
+                // Disable warning messages
+                Tiff.SetErrorHandler(new DisableErrorHandler());
 
                 // open a TIFF stored in the stream
                 using (Tiff tiff = Tiff.ClientOpen("in-memory", "r", tiffStream, new TiffStream()))

--- a/IronSoftware.Drawing/IronSoftware.Drawing.Common/AnyBitmap.cs
+++ b/IronSoftware.Drawing/IronSoftware.Drawing.Common/AnyBitmap.cs
@@ -463,7 +463,7 @@ namespace IronSoftware.Drawing
         /// Create a new Bitmap from a a Byte Span.
         /// </summary>
         /// <param name="span">A Byte Span of image data in any common format.</param>
-        /// <param name="preserveOriginalFormat">Determine whether load <see cref="SixLabors.ImageSharp.Image"/> as its original pixel format or Rgba32.
+        /// <param name="preserveOriginalFormat">Determine whether to load <see cref="SixLabors.ImageSharp.Image"/> as its original pixel format or Rgba32.
         /// Default is true. Set to false to load as Rgba32.</param>
         public static AnyBitmap FromSpan(ReadOnlySpan<byte> span, bool preserveOriginalFormat = true)
         {
@@ -474,7 +474,7 @@ namespace IronSoftware.Drawing
         /// Create a new Bitmap from a a Byte Array.
         /// </summary>
         /// <param name="bytes">A ByteArray of image data in any common format.</param>
-        /// <param name="preserveOriginalFormat">Determine whether load <see cref="SixLabors.ImageSharp.Image"/> as its original pixel format or Rgba32.
+        /// <param name="preserveOriginalFormat">Determine whether to load <see cref="SixLabors.ImageSharp.Image"/> as its original pixel format or Rgba32.
         /// Default is true. Set to false to load as Rgba32.</param>
         public static AnyBitmap FromBytes(byte[] bytes, bool preserveOriginalFormat = true)
         {
@@ -485,7 +485,7 @@ namespace IronSoftware.Drawing
         /// Create a new Bitmap from a <see cref="Stream"/> (bytes).
         /// </summary>
         /// <param name="stream">A <see cref="Stream"/> of image data in any common format.</param> 
-        /// <param name="preserveOriginalFormat">Determine whether load <see cref="SixLabors.ImageSharp.Image"/> as its original pixel format or Rgba32.
+        /// <param name="preserveOriginalFormat">Determine whether to load <see cref="SixLabors.ImageSharp.Image"/> as its original pixel format or Rgba32.
         /// Default is true. Set to false to load as Rgba32.</param>
         /// <seealso cref="FromStream(Stream, bool)"/>
         /// <seealso cref="AnyBitmap"/>
@@ -498,7 +498,7 @@ namespace IronSoftware.Drawing
         /// Create a new Bitmap from a <see cref="Stream"/> (bytes).
         /// </summary>
         /// <param name="stream">A <see cref="Stream"/> of image data in any common format.</param>
-        /// <param name="preserveOriginalFormat">Determine whether load <see cref="SixLabors.ImageSharp.Image"/> as its original pixel format or Rgba32.
+        /// <param name="preserveOriginalFormat">Determine whether to load <see cref="SixLabors.ImageSharp.Image"/> as its original pixel format or Rgba32.
         /// Default is true. Set to false to load as Rgba32.</param>
         /// <seealso cref="FromStream(MemoryStream, bool)"/>
         /// <seealso cref="AnyBitmap"/>
@@ -511,7 +511,7 @@ namespace IronSoftware.Drawing
         /// Construct a new Bitmap from binary data (byte span).
         /// </summary>
         /// <param name="span">A byte span of image data in any common format.</param>
-        /// <param name="preserveOriginalFormat">Determine whether load <see cref="SixLabors.ImageSharp.Image"/> as its original pixel format or Rgba32.
+        /// <param name="preserveOriginalFormat">Determine whether to load <see cref="SixLabors.ImageSharp.Image"/> as its original pixel format or Rgba32.
         /// Default is true. Set to false to load as Rgba32.</param>
         /// <seealso cref="AnyBitmap"/>
         public AnyBitmap(ReadOnlySpan<byte> span, bool preserveOriginalFormat = true)
@@ -523,7 +523,7 @@ namespace IronSoftware.Drawing
         /// Construct a new Bitmap from binary data (bytes).
         /// </summary>
         /// <param name="bytes">A ByteArray of image data in any common format.</param>
-        /// <param name="preserveOriginalFormat">Determine whether load <see cref="SixLabors.ImageSharp.Image"/> as its original pixel format or Rgba32.
+        /// <param name="preserveOriginalFormat">Determine whether to load <see cref="SixLabors.ImageSharp.Image"/> as its original pixel format or Rgba32.
         /// Default is true. Set to false to load as Rgba32.</param>
         /// <seealso cref="FromBytes"/>
         /// <seealso cref="AnyBitmap"/>
@@ -536,7 +536,7 @@ namespace IronSoftware.Drawing
         /// Construct a new Bitmap from a <see cref="Stream"/> (bytes).
         /// </summary>
         /// <param name="stream">A <see cref="Stream"/> of image data in any common format.</param>
-        /// <param name="preserveOriginalFormat">Determine whether load <see cref="SixLabors.ImageSharp.Image"/> as its original pixel format or Rgba32.
+        /// <param name="preserveOriginalFormat">Determine whether to load <see cref="SixLabors.ImageSharp.Image"/> as its original pixel format or Rgba32.
         /// Default is true. Set to false to load as Rgba32.</param>
         /// <seealso cref="FromStream(Stream, bool)"/>
         /// <seealso cref="AnyBitmap"/>
@@ -549,7 +549,7 @@ namespace IronSoftware.Drawing
         /// Construct a new Bitmap from a <see cref="Stream"/> (bytes).
         /// </summary>
         /// <param name="stream">A <see cref="Stream"/> of image data in any common format.</param>
-        /// <param name="preserveOriginalFormat">Determine whether load <see cref="SixLabors.ImageSharp.Image"/> as its original pixel format or Rgba32.
+        /// <param name="preserveOriginalFormat">Determine whether to load <see cref="SixLabors.ImageSharp.Image"/> as its original pixel format or Rgba32.
         /// Default is true. Set to false to load as Rgba32.</param>
         /// <seealso cref="FromStream(MemoryStream, bool)"/>
         /// <seealso cref="AnyBitmap"/>
@@ -574,7 +574,7 @@ namespace IronSoftware.Drawing
         /// Construct a new Bitmap from a file.
         /// </summary>
         /// <param name="file">A fully qualified file path./</param>
-        /// <param name="preserveOriginalFormat">Determine whether load <see cref="SixLabors.ImageSharp.Image"/> as its original pixel format or Rgba32.
+        /// <param name="preserveOriginalFormat">Determine whether to load <see cref="SixLabors.ImageSharp.Image"/> as its original pixel format or Rgba32.
         /// Default is true. Set to false to load as Rgba32.</param>
         /// <seealso cref="FromFile"/>
         /// <seealso cref="AnyBitmap"/>
@@ -587,7 +587,7 @@ namespace IronSoftware.Drawing
         /// Construct a new Bitmap from a Uri
         /// </summary>
         /// <param name="uri">The uri of the image.</param>
-        /// <param name="preserveOriginalFormat">Determine whether load <see cref="SixLabors.ImageSharp.Image"/> as its original pixel format or Rgba32.
+        /// <param name="preserveOriginalFormat">Determine whether to load <see cref="SixLabors.ImageSharp.Image"/> as its original pixel format or Rgba32.
         /// Default is true. Set to false to load as Rgba32.</param>
         /// <seealso cref="FromUriAsync"/>
         /// <seealso cref="AnyBitmap"/>
@@ -619,7 +619,7 @@ namespace IronSoftware.Drawing
         /// Create a new Bitmap from a file.
         /// </summary>
         /// <param name="file">A fully qualified file path.</param>
-        /// <param name="preserveOriginalFormat">Determine whether load <see cref="SixLabors.ImageSharp.Image"/> as its original pixel format or Rgba32.
+        /// <param name="preserveOriginalFormat">Determine whether to load <see cref="SixLabors.ImageSharp.Image"/> as its original pixel format or Rgba32.
         /// Default is true. Set to false to load as Rgba32.</param>
         /// <seealso cref="FromFile"/>
         /// <seealso cref="AnyBitmap"/>
@@ -639,7 +639,7 @@ namespace IronSoftware.Drawing
         /// Construct a new Bitmap from a Uri
         /// </summary>
         /// <param name="uri">The uri of the image.</param>
-        /// <param name="preserveOriginalFormat">Determine whether load <see cref="SixLabors.ImageSharp.Image"/> as its original pixel format or Rgba32.
+        /// <param name="preserveOriginalFormat">Determine whether to load <see cref="SixLabors.ImageSharp.Image"/> as its original pixel format or Rgba32.
         /// Default is true. Set to false to load as Rgba32.</param>
         /// <returns></returns>
         /// <seealso cref="AnyBitmap"/>
@@ -662,7 +662,7 @@ namespace IronSoftware.Drawing
         /// Construct a new Bitmap from a Uri
         /// </summary>
         /// <param name="uri">The uri of the image.</param>
-        /// <param name="preserveOriginalFormat">Determine whether load <see cref="SixLabors.ImageSharp.Image"/> as its original pixel format or Rgba32.
+        /// <param name="preserveOriginalFormat">Determine whether to load <see cref="SixLabors.ImageSharp.Image"/> as its original pixel format or Rgba32.
         /// Default is true. Set to false to load as Rgba32.</param>
         /// <returns></returns>
         /// <seealso cref="AnyBitmap"/>

--- a/IronSoftware.Drawing/IronSoftware.Drawing.Common/IronSoftware.Drawing.Common.csproj
+++ b/IronSoftware.Drawing/IronSoftware.Drawing.Common/IronSoftware.Drawing.Common.csproj
@@ -1,4 +1,4 @@
-<Project Sdk="Microsoft.NET.Sdk">
+﻿<Project Sdk="Microsoft.NET.Sdk">
 
 	<PropertyGroup>
 		<AssemblyOriginatorKeyFile>IronSoftware.Drawing.Common.snk</AssemblyOriginatorKeyFile>
@@ -25,7 +25,7 @@
 		<PackageReference Include="BitMiracle.LibTiff.NET" Version="2.4.649" />
 		<PackageReference Include="Microsoft.Maui.Graphics" Version="7.0.92" />
         <PackageReference Include="SkiaSharp" Version="2.88.7" />
-        <PackageReference Include="IronSoftware.Drawing.Abstractions" Version="2025.2.6" />
+        <PackageReference Include="IronSoftware.Drawing.Abstractions" Version="2025.4.2" />
 		<PackageReference Include="SkiaSharp.Svg" Version="1.60.0" />
 		<PackageReference Include="System.Drawing.Common" Version="6.0.0" />
 		<PackageReference Include="System.Memory" Version="4.5.5" />

--- a/NuGet/IronSoftware.Drawing.nuspec
+++ b/NuGet/IronSoftware.Drawing.nuspec
@@ -39,7 +39,8 @@ Supports:
 
 For general support and technical inquiries, please email us at: support@ironsoftware.com</description>
 		<summary>IronSoftware.System.Drawing is an open-source solution for .NET developers to replace System.Drawing.Common with a universal and flexible library.</summary>
-		<releaseNotes>- Updates internal dependencies.</releaseNotes>
+		<releaseNotes>- Updates internal dependencies.
+    - Disable warning messages from BitMiracle.LibTiff.NET.</releaseNotes>
 		<copyright>Copyright © Iron Software 2022-2025</copyright>
 		<tags>Images, Bitmap, SkiaSharp, SixLabors, BitMiracle, Maui, SVG, TIFF, TIF, GIF, JPEG, PNG, Color, Rectangle, Drawing, C#, VB.NET, ASPX, create, render, generate, standard, netstandard2.0, core, netcore</tags>
 		<repository type="git" url="https://github.com/iron-software/IronSoftware.Drawing.Common" commit="$commit$" />

--- a/NuGet/IronSoftware.Drawing.nuspec
+++ b/NuGet/IronSoftware.Drawing.nuspec
@@ -54,8 +54,8 @@ For general support and technical inquiries, please email us at: support@ironsof
 			</group>
 			<group targetFramework="net60">
 				<dependency id="IronSoftware.Drawing.Abstractions" version="2025.4.2" />
-				<dependency id="SixLabors.ImageSharp" version="3.1.7" />
-				<dependency id="SixLabors.ImageSharp.Drawing" version="2.1.5" />
+				<dependency id="SixLabors.ImageSharp" version="3.1.8" />
+				<dependency id="SixLabors.ImageSharp.Drawing" version="2.1.6" />
 				<dependency id="BitMiracle.LibTiff.NET" version="2.4.649" />
 				<dependency id="System.Memory" version="4.5.5" />
 			</group>

--- a/NuGet/IronSoftware.Drawing.nuspec
+++ b/NuGet/IronSoftware.Drawing.nuspec
@@ -39,8 +39,7 @@ Supports:
 
 For general support and technical inquiries, please email us at: support@ironsoftware.com</description>
 		<summary>IronSoftware.System.Drawing is an open-source solution for .NET developers to replace System.Drawing.Common with a universal and flexible library.</summary>
-		<releaseNotes>- Fixes incorrect HorizontalResolution and VerticalResolution of AnyBitmap images.
-		- Improves library's internal functionality and performance.</releaseNotes>
+		<releaseNotes>- Updates internal dependencies.</releaseNotes>
 		<copyright>Copyright © Iron Software 2022-2025</copyright>
 		<tags>Images, Bitmap, SkiaSharp, SixLabors, BitMiracle, Maui, SVG, TIFF, TIF, GIF, JPEG, PNG, Color, Rectangle, Drawing, C#, VB.NET, ASPX, create, render, generate, standard, netstandard2.0, core, netcore</tags>
 		<repository type="git" url="https://github.com/iron-software/IronSoftware.Drawing.Common" commit="$commit$" />

--- a/NuGet/IronSoftware.Drawing.nuspec
+++ b/NuGet/IronSoftware.Drawing.nuspec
@@ -46,14 +46,14 @@ For general support and technical inquiries, please email us at: support@ironsof
 		<repository type="git" url="https://github.com/iron-software/IronSoftware.Drawing.Common" commit="$commit$" />
 		<dependencies>
 			<group targetFramework="netstandard2.0">
-				<dependency id="IronSoftware.Drawing.Abstractions" version="2025.2.6" />
+				<dependency id="IronSoftware.Drawing.Abstractions" version="2025.4.2" />
 				<dependency id="SixLabors.ImageSharp" version="2.1.10" />
 				<dependency id="SixLabors.ImageSharp.Drawing" version="1.0.0" />
 				<dependency id="BitMiracle.LibTiff.NET" version="2.4.649" />
 				<dependency id="System.Memory" version="4.5.5" />
 			</group>
 			<group targetFramework="net60">
-				<dependency id="IronSoftware.Drawing.Abstractions" version="2025.2.6" />
+				<dependency id="IronSoftware.Drawing.Abstractions" version="2025.4.2" />
 				<dependency id="SixLabors.ImageSharp" version="3.1.7" />
 				<dependency id="SixLabors.ImageSharp.Drawing" version="2.1.5" />
 				<dependency id="BitMiracle.LibTiff.NET" version="2.4.649" />


### PR DESCRIPTION
### Title
Make sure the title of the PR is descriptive and summarizes the changes made.

### Description
Add an option to determine whether keeping original pixel format or load as `<Rgba32>` while loading image.
This PR aims eliminate the redundancy in IronOcr code base while converting `AnyBitmap` to `Leptonica.Pix`. Tesseract uses `Leptonica.Pix` as an input which require to convert from 32-bit image.

Fixes #(issue number)
[DW-33](https://ironsoftware.atlassian.net/browse/DW-33)
[DW-32](https://ironsoftware.atlassian.net/browse/DW-32)

### Type of change
Please select the relevant option by placing an 'x' inside the brackets, like this: [x].

- [ ] 🐛 Bug fix (non-breaking change which fixes an issue)
- [x] ✨ New feature (non-breaking change which adds functionality)
- [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] 🏗️ Internal/structural update (non-breaking change that improves code quality, organization, or performance)
- [x] 📚 This change requires a documentation update
- [ ] 🚀 DevOps build chain modification for release
- [ ] 🤖 DevOps build chain modification for CI

### How Has This Been Tested?
Add a new unit test and set `preserveOriginalFormat` to both true and false. Then verify the `AnyBitmap.BitsPerPixel`.

### Checklist:
Please run through the checklist as much as possible and mark the items completed by placing an 'x' inside the brackets, like this: [x].

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] I have successfully run all unit tests on Windows
- [x] I have successfully run all unit tests on Linux

### Additional Context
Add any other context, screenshots, or information about the pull request here.


[DW-33]: https://ironsoftware.atlassian.net/browse/DW-33?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

[DW-32]: https://ironsoftware.atlassian.net/browse/DW-32?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ