### PR TITLE
hotfix LoadAndResizeImage crashed

### DIFF
--- a/IronSoftware.Drawing/IronSoftware.Drawing.Common.Tests/UnitTests/AnyBitmapFunctionality.cs
+++ b/IronSoftware.Drawing/IronSoftware.Drawing.Common.Tests/UnitTests/AnyBitmapFunctionality.cs
@@ -192,7 +192,7 @@ namespace IronSoftware.Drawing.Common.Tests.UnitTests
 
             bitmap.Save("expected.bmp");
             anyBitmap.SaveAs("result.bmp");
-
+            anyBitmap.GetPixel(0, 0); //should not throw error
             AssertImageAreEqual("expected.bmp", "result.bmp", true);
         }
 
@@ -217,7 +217,7 @@ namespace IronSoftware.Drawing.Common.Tests.UnitTests
 
             bitmap.Save("expected.bmp");
             anyBitmap.SaveAs("result.bmp");
-
+            anyBitmap.GetPixel(0, 0); //should not throw error
             AssertImageAreEqual("expected.bmp", "result.bmp", true);
         }
 
@@ -397,7 +397,7 @@ namespace IronSoftware.Drawing.Common.Tests.UnitTests
 
             SaveSkiaBitmap(skBitmap, "expected.png");
             anyBitmap.SaveAs("result.png");
-
+            anyBitmap.GetPixel(0, 0); //should not throw error
             AssertImageAreEqual("expected.png", "result.png", true);
         }
 
@@ -430,7 +430,7 @@ namespace IronSoftware.Drawing.Common.Tests.UnitTests
 
             SaveSkiaImage(skImage, "expected.png");
             anyBitmap.SaveAs("result.png");
-
+            anyBitmap.GetPixel(0, 0); //should not throw error
             AssertImageAreEqual("expected.png", "result.png", true);
         }
 
@@ -463,7 +463,7 @@ namespace IronSoftware.Drawing.Common.Tests.UnitTests
 
             imgSharp.Save("expected.bmp");
             anyBitmap.SaveAs("result.bmp");
-
+            anyBitmap.GetPixel(0, 0); //should not throw error
             AssertImageAreEqual("expected.bmp", "result.bmp", true);
         }
 
@@ -524,7 +524,7 @@ namespace IronSoftware.Drawing.Common.Tests.UnitTests
 
             bitmap.Save("expected.png");
             anyBitmap.SaveAs("result.png");
-
+            anyBitmap.GetPixel(0, 0); //should not throw error
             AssertImageAreEqual("expected.png", "result.png", true);
         }
 
@@ -755,6 +755,7 @@ namespace IronSoftware.Drawing.Common.Tests.UnitTests
             var resizeAnyBitmap = new AnyBitmap(anyBitmap, width, height);
             _ = resizeAnyBitmap.Width.Should().Be(width);
             _ = resizeAnyBitmap.Height.Should().Be(height);
+            resizeAnyBitmap.GetPixel(0, 0); //should not throw error
         }
 
         [FactWithAutomaticDisplayName]
@@ -936,7 +937,7 @@ namespace IronSoftware.Drawing.Common.Tests.UnitTests
 
             SaveMauiImages(image, "expected.bmp");
             anyBitmap.SaveAs("result.bmp");
-
+            anyBitmap.GetPixel(0, 0); //should not throw error
             AssertImageAreEqual("expected.bmp", "result.bmp", true);
         }
 
@@ -948,7 +949,7 @@ namespace IronSoftware.Drawing.Common.Tests.UnitTests
 
             anyBitmap.SaveAs("expected.bmp");
             SaveMauiImages(image, "result.bmp");
-
+            anyBitmap.GetPixel(0, 0); //should not throw error
             AssertImageAreEqual("expected.bmp", "result.bmp", true);
         }
 #endif
@@ -972,6 +973,7 @@ namespace IronSoftware.Drawing.Common.Tests.UnitTests
 
             blankBitmap.Width.Should().Be(8);
             blankBitmap.Height.Should().Be(8);
+            blankBitmap.GetPixel(0, 0); //should not throw error
         }
 
         [FactWithAutomaticDisplayName]
@@ -1070,7 +1072,7 @@ namespace IronSoftware.Drawing.Common.Tests.UnitTests
 
             image.Save("expected.bmp");
             anyBitmap.SaveAs("result.bmp");
-
+            anyBitmap.GetPixel(0, 0); //should not throw error
             AssertLargeImageAreEqual("expected.bmp", "result.bmp", true);
         }
 #endif

--- a/IronSoftware.Drawing/IronSoftware.Drawing.Common/AnyBitmap.cs
+++ b/IronSoftware.Drawing/IronSoftware.Drawing.Common/AnyBitmap.cs
@@ -3236,7 +3236,7 @@ namespace IronSoftware.Drawing
             _lazyImage = new Lazy<IReadOnlyList<Image>>(() =>
             {
 
-                using var image = Image.Load<Rgba32>(Binary);
+                var image = Image.Load<Rgba32>(Binary);
                 image.Mutate(img => img.Resize(width, height));
 
                 //update Binary


### PR DESCRIPTION
### Title
Hotfix LoadAndResizeImage crashed

### Description
LoadAndResizeImage will throw images is disposed since we have invalid using statement. so images in _lazyImage is already disposed.

Fixes #(issue number)
If this PR addresses an existing issue, mention the issue number here.

### Type of change
Please select the relevant option by placing an 'x' inside the brackets, like this: [x].

- [x] 🐛 Bug fix (non-breaking change which fixes an issue)
- [ ] ✨ New feature (non-breaking change which adds functionality)
- [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] 🏗️ Internal/structural update (non-breaking change that improves code quality, organization, or performance)
- [ ] 📚 This change requires a documentation update
- [ ] 🚀 DevOps build chain modification for release
- [ ] 🤖 DevOps build chain modification for CI

### How Has This Been Tested?
Added `anyBitmap.GetPixel(0, 0); //should not throw error` in unit tests 

### Checklist:
Please run through the checklist as much as possible and mark the items completed by placing an 'x' inside the brackets, like this: [x].

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] I have successfully run all unit tests on Windows
- [ ] I have successfully run all unit tests on Linux

### Additional Context
Add any other context, screenshots, or information about the pull request here.
