### PR TITLE
[master] Prepare for January 2026 release

### DIFF
--- a/IronSoftware.Drawing/IronSoftware.Drawing.Common.Tests/UnitTests/AnyBitmapFunctionality.cs
+++ b/IronSoftware.Drawing/IronSoftware.Drawing.Common.Tests/UnitTests/AnyBitmapFunctionality.cs
@@ -121,7 +121,7 @@ namespace IronSoftware.Drawing.Common.Tests.UnitTests
         [FactWithAutomaticDisplayName]
         public async void Create_AnyBitmap_by_Uri_Async()
         {
-            var uri = new Uri("https://upload.wikimedia.org/wikipedia/commons/thumb/e/ea/Van_Gogh_-_Starry_Night_-_Google_Art_Project.jpg/1200px-Van_Gogh_-_Starry_Night_-_Google_Art_Project.jpg");
+            var uri = new Uri("https://ironsoftware.com/img/ironsoftware_hero_section/bg-hero-part.png");
 
             AnyBitmap bitmap = await AnyBitmap.FromUriAsync(uri);
             _ = bitmap.TrySaveAs("result.bmp");

--- a/IronSoftware.Drawing/IronSoftware.Drawing.Common.Tests/UnitTests/FontFunctionality.cs
+++ b/IronSoftware.Drawing/IronSoftware.Drawing.Common.Tests/UnitTests/FontFunctionality.cs
@@ -371,7 +371,7 @@ namespace IronSoftware.Drawing.Common.Tests.UnitTests
                 _ => fontName.Replace(" ", "")
             };
 
-            Assert.Contains($"You have set a non PDF standatd FontType: {expectedFontName}, Please select one from IronSoftware.Drawing.FontTypes.", ex.Message);
+            Assert.Contains($"You have set a non PDF standard FontType: {expectedFontName}, Please select one from IronSoftware.Drawing.FontTypes.", ex.Message);
         }
 
 #if !NETFRAMEWORK

--- a/IronSoftware.Drawing/IronSoftware.Drawing.Common.Tests/UnitTests/FontFunctionality.cs
+++ b/IronSoftware.Drawing/IronSoftware.Drawing.Common.Tests/UnitTests/FontFunctionality.cs
@@ -371,7 +371,7 @@ namespace IronSoftware.Drawing.Common.Tests.UnitTests
                 _ => fontName.Replace(" ", "")
             };
 
-            Assert.Contains($"You have set a non PDF standard FontType: {expectedFontName}, Please select one from IronSoftware.Drawing.FontTypes.", ex.Message);
+            Assert.Contains($"You have set a non-PDF standard FontType: {expectedFontName}, Please select one from IronSoftware.Drawing.FontTypes.", ex.Message);
         }
 
 #if !NETFRAMEWORK

--- a/IronSoftware.Drawing/IronSoftware.Drawing.Common/AnyBitmap.cs
+++ b/IronSoftware.Drawing/IronSoftware.Drawing.Common/AnyBitmap.cs
@@ -21,11 +21,12 @@ using System.IO;
 using System.Linq;
 using System.Net;
 using System.Net.Http;
-using System.Reflection;
 using System.Runtime.CompilerServices;
 using System.Runtime.InteropServices;
 using System.Threading;
 using System.Threading.Tasks;
+
+using IronSoftware.Abstractions;
 
 namespace IronSoftware.Drawing
 {

--- a/IronSoftware.Drawing/IronSoftware.Drawing.Common/FontTypes.cs
+++ b/IronSoftware.Drawing/IronSoftware.Drawing.Common/FontTypes.cs
@@ -146,7 +146,7 @@ namespace IronSoftware.Drawing
                 "TimesNewRoman-BoldItalic" => TimesNewRomanBoldItalic,
                 "TimesNewRoman-Italic" => TimesNewRomanItalic,
                 "ZapfDingbats" => ZapfDingbats,
-                _ => throw new System.InvalidCastException($"You have set a non PDF standatd FontType: {fontName}, Please select one from IronSoftware.Drawing.FontTypes.")
+                _ => throw new System.InvalidCastException($"You have set a non-PDF standard FontType: {fontName}, Please select one from IronSoftware.Drawing.FontTypes.")
             };
         }
     }

--- a/IronSoftware.Drawing/IronSoftware.Drawing.Common/IronSoftware.Drawing.Common.csproj
+++ b/IronSoftware.Drawing/IronSoftware.Drawing.Common/IronSoftware.Drawing.Common.csproj
@@ -25,7 +25,7 @@
         <PackageReference Include="BitMiracle.LibTiff.NET" Version="2.4.649" />
         <PackageReference Include="Microsoft.Maui.Graphics" Version="7.0.92" />
         <PackageReference Include="SkiaSharp" Version="2.88.7" />
-        <PackageReference Include="IronSoftware.Drawing.Abstractions" Version="2026.2.40142-ci" />
+        <PackageReference Include="IronSoftware.Drawing.Abstractions" Version="2026.1.1" />
         <PackageReference Include="SkiaSharp.Svg" Version="1.60.0" />
         <PackageReference Include="System.Drawing.Common" Version="6.0.0" />
         <PackageReference Include="System.Memory" Version="4.5.5" />
@@ -35,13 +35,13 @@
 	<Choose>
 		<When Condition="'$(TargetFramework)' == 'net60'">
 			<ItemGroup>
-				<PackageReference Include="SixLabors.ImageSharp" Version="3.1.11" />
+				<PackageReference Include="SixLabors.ImageSharp" Version="3.1.12" />
 				<PackageReference Include="SixLabors.ImageSharp.Drawing" Version="2.1.7" />
 			</ItemGroup>
 		</When>
 		<Otherwise>
 			<ItemGroup>
-				<PackageReference Include="SixLabors.ImageSharp" Version="2.1.11" />
+				<PackageReference Include="SixLabors.ImageSharp" Version="2.1.13" />
 				<PackageReference Include="SixLabors.ImageSharp.Drawing" Version="1.0.0" />
 			</ItemGroup>
 		</Otherwise>

--- a/IronSoftware.Drawing/IronSoftware.Drawing.Common/IronSoftware.Drawing.Common.csproj
+++ b/IronSoftware.Drawing/IronSoftware.Drawing.Common/IronSoftware.Drawing.Common.csproj
@@ -25,7 +25,7 @@
         <PackageReference Include="BitMiracle.LibTiff.NET" Version="2.4.649" />
         <PackageReference Include="Microsoft.Maui.Graphics" Version="7.0.92" />
         <PackageReference Include="SkiaSharp" Version="2.88.7" />
-        <PackageReference Include="IronSoftware.Drawing.Abstractions" Version="2026.1.1-prerelease" />
+        <PackageReference Include="IronSoftware.Drawing.Abstractions" Version="2026.1.40077-ci" />
         <PackageReference Include="SkiaSharp.Svg" Version="1.60.0" />
         <PackageReference Include="System.Drawing.Common" Version="6.0.0" />
         <PackageReference Include="System.Memory" Version="4.5.5" />

--- a/IronSoftware.Drawing/IronSoftware.Drawing.Common/IronSoftware.Drawing.Common.csproj
+++ b/IronSoftware.Drawing/IronSoftware.Drawing.Common/IronSoftware.Drawing.Common.csproj
@@ -25,7 +25,7 @@
         <PackageReference Include="BitMiracle.LibTiff.NET" Version="2.4.649" />
         <PackageReference Include="Microsoft.Maui.Graphics" Version="7.0.92" />
         <PackageReference Include="SkiaSharp" Version="2.88.7" />
-        <PackageReference Include="IronSoftware.Drawing.Abstractions" Version="2025.9.4-prerelease" />
+        <PackageReference Include="IronSoftware.Drawing.Abstractions" Version="2026.1.1-prerelease" />
         <PackageReference Include="SkiaSharp.Svg" Version="1.60.0" />
         <PackageReference Include="System.Drawing.Common" Version="6.0.0" />
         <PackageReference Include="System.Memory" Version="4.5.5" />

--- a/IronSoftware.Drawing/IronSoftware.Drawing.Common/IronSoftware.Drawing.Common.csproj
+++ b/IronSoftware.Drawing/IronSoftware.Drawing.Common/IronSoftware.Drawing.Common.csproj
@@ -25,7 +25,7 @@
         <PackageReference Include="BitMiracle.LibTiff.NET" Version="2.4.649" />
         <PackageReference Include="Microsoft.Maui.Graphics" Version="7.0.92" />
         <PackageReference Include="SkiaSharp" Version="2.88.7" />
-        <PackageReference Include="IronSoftware.Drawing.Abstractions" Version="2026.1.1" />
+        <PackageReference Include="IronSoftware.Drawing.Abstractions" Version="2026.1.2" />
         <PackageReference Include="SkiaSharp.Svg" Version="1.60.0" />
         <PackageReference Include="System.Drawing.Common" Version="6.0.0" />
         <PackageReference Include="System.Memory" Version="4.5.5" />

--- a/IronSoftware.Drawing/IronSoftware.Drawing.Common/IronSoftware.Drawing.Common.csproj
+++ b/IronSoftware.Drawing/IronSoftware.Drawing.Common/IronSoftware.Drawing.Common.csproj
@@ -25,7 +25,7 @@
         <PackageReference Include="BitMiracle.LibTiff.NET" Version="2.4.649" />
         <PackageReference Include="Microsoft.Maui.Graphics" Version="7.0.92" />
         <PackageReference Include="SkiaSharp" Version="2.88.7" />
-        <PackageReference Include="IronSoftware.Drawing.Abstractions" Version="2026.1.40077-ci" />
+        <PackageReference Include="IronSoftware.Drawing.Abstractions" Version="2026.2.40142-ci" />
         <PackageReference Include="SkiaSharp.Svg" Version="1.60.0" />
         <PackageReference Include="System.Drawing.Common" Version="6.0.0" />
         <PackageReference Include="System.Memory" Version="4.5.5" />

--- a/IronSoftware.Drawing/IronSoftware.Drawing.Common/IronSoftware.Drawing.Common.csproj
+++ b/IronSoftware.Drawing/IronSoftware.Drawing.Common/IronSoftware.Drawing.Common.csproj
@@ -22,14 +22,14 @@
 	</PropertyGroup>
 
 	<ItemGroup>
-		<PackageReference Include="BitMiracle.LibTiff.NET" Version="2.4.649" />
-		<PackageReference Include="Microsoft.Maui.Graphics" Version="7.0.92" />
+        <PackageReference Include="BitMiracle.LibTiff.NET" Version="2.4.649" />
+        <PackageReference Include="Microsoft.Maui.Graphics" Version="7.0.92" />
         <PackageReference Include="SkiaSharp" Version="2.88.7" />
-        <PackageReference Include="IronSoftware.Drawing.Abstractions" Version="2025.4.2" />
-		<PackageReference Include="SkiaSharp.Svg" Version="1.60.0" />
-		<PackageReference Include="System.Drawing.Common" Version="6.0.0" />
-		<PackageReference Include="System.Memory" Version="4.5.5" />
-		<PackageReference Include="Microsoft.SourceLink.GitHub" Version="1.1.1" PrivateAssets="All" />
+        <PackageReference Include="IronSoftware.Drawing.Abstractions" Version="2025.9.4-prerelease" />
+        <PackageReference Include="SkiaSharp.Svg" Version="1.60.0" />
+        <PackageReference Include="System.Drawing.Common" Version="6.0.0" />
+        <PackageReference Include="System.Memory" Version="4.5.5" />
+        <PackageReference Include="Microsoft.SourceLink.GitHub" Version="1.1.1" PrivateAssets="All" />
 	</ItemGroup>
 
 	<Choose>

--- a/NuGet/IronSoftware.Drawing.nuspec
+++ b/NuGet/IronSoftware.Drawing.nuspec
@@ -48,14 +48,14 @@ For general support and technical inquiries, please email us at: support@ironsof
 		<repository type="git" url="https://github.com/iron-software/IronSoftware.Drawing.Common" commit="$commit$" />
 		<dependencies>
 			<group targetFramework="netstandard2.0">
-				<dependency id="IronSoftware.Drawing.Abstractions" version="2026.1.1-prerelease" />
+				<dependency id="IronSoftware.Drawing.Abstractions" version="2026.1.40077-ci" />
 				<dependency id="SixLabors.ImageSharp" version="2.1.11" />
 				<dependency id="SixLabors.ImageSharp.Drawing" version="1.0.0" />
 				<dependency id="BitMiracle.LibTiff.NET" version="2.4.649" />
 				<dependency id="System.Memory" version="4.5.5" />
 			</group>
 			<group targetFramework="net60">
-				<dependency id="IronSoftware.Drawing.Abstractions" version="2026.1.1-prerelease" />
+				<dependency id="IronSoftware.Drawing.Abstractions" version="2026.1.40077-ci" />
 				<dependency id="SixLabors.ImageSharp" version="3.1.11" />
 				<dependency id="SixLabors.ImageSharp.Drawing" version="2.1.7" />
 				<dependency id="BitMiracle.LibTiff.NET" version="2.4.649" />

--- a/NuGet/IronSoftware.Drawing.nuspec
+++ b/NuGet/IronSoftware.Drawing.nuspec
@@ -40,23 +40,22 @@ Supports:
 
 For general support and technical inquiries, please email us at: support@ironsoftware.com</description>
 		<summary>IronSoftware.System.Drawing is an open-source solution for .NET developers to replace System.Drawing.Common with a universal and flexible library.</summary>
-		<releaseNotes>- Optimizes AnyBitmap memory usage.
-		- Updates Color.FromName to align with System.Drawing.
-		- Adds support for RebeccaPurple color.</releaseNotes>
-		<copyright>Copyright © Iron Software 2022-2025</copyright>
+		<releaseNotes>- Updates IronSoftware.Drawing.Abstractions to 2026.1.1.
+- Updates SixLabors.ImageSharp to 2.1.13 (netstandard2.0) and 3.1.12 (net6.0).</releaseNotes>
+		<copyright>Copyright © Iron Software 2022-2026</copyright>
 		<tags>Images, Bitmap, SkiaSharp, SixLabors, BitMiracle, Maui, SVG, TIFF, TIF, GIF, JPEG, PNG, Color, Rectangle, Drawing, C#, VB.NET, ASPX, create, render, generate, standard, netstandard2.0, core, netcore</tags>
 		<repository type="git" url="https://github.com/iron-software/IronSoftware.Drawing.Common" commit="$commit$" />
 		<dependencies>
 			<group targetFramework="netstandard2.0">
-				<dependency id="IronSoftware.Drawing.Abstractions" version="2026.2.40142-ci" />
-				<dependency id="SixLabors.ImageSharp" version="2.1.11" />
+				<dependency id="IronSoftware.Drawing.Abstractions" version="2026.1.1" />
+				<dependency id="SixLabors.ImageSharp" version="2.1.13" />
 				<dependency id="SixLabors.ImageSharp.Drawing" version="1.0.0" />
 				<dependency id="BitMiracle.LibTiff.NET" version="2.4.649" />
 				<dependency id="System.Memory" version="4.5.5" />
 			</group>
 			<group targetFramework="net60">
-				<dependency id="IronSoftware.Drawing.Abstractions" version="2026.2.40142-ci" />
-				<dependency id="SixLabors.ImageSharp" version="3.1.11" />
+				<dependency id="IronSoftware.Drawing.Abstractions" version="2026.1.1" />
+				<dependency id="SixLabors.ImageSharp" version="3.1.12" />
 				<dependency id="SixLabors.ImageSharp.Drawing" version="2.1.7" />
 				<dependency id="BitMiracle.LibTiff.NET" version="2.4.649" />
 				<dependency id="System.Memory" version="4.5.5" />

--- a/NuGet/IronSoftware.Drawing.nuspec
+++ b/NuGet/IronSoftware.Drawing.nuspec
@@ -48,14 +48,14 @@ For general support and technical inquiries, please email us at: support@ironsof
 		<repository type="git" url="https://github.com/iron-software/IronSoftware.Drawing.Common" commit="$commit$" />
 		<dependencies>
 			<group targetFramework="netstandard2.0">
-				<dependency id="IronSoftware.Drawing.Abstractions" version="2025.9.4-prerelease" />
+				<dependency id="IronSoftware.Drawing.Abstractions" version="2026.1.1-prerelease" />
 				<dependency id="SixLabors.ImageSharp" version="2.1.11" />
 				<dependency id="SixLabors.ImageSharp.Drawing" version="1.0.0" />
 				<dependency id="BitMiracle.LibTiff.NET" version="2.4.649" />
 				<dependency id="System.Memory" version="4.5.5" />
 			</group>
 			<group targetFramework="net60">
-				<dependency id="IronSoftware.Drawing.Abstractions" version="2025.9.4-prerelease" />
+				<dependency id="IronSoftware.Drawing.Abstractions" version="2026.1.1-prerelease" />
 				<dependency id="SixLabors.ImageSharp" version="3.1.11" />
 				<dependency id="SixLabors.ImageSharp.Drawing" version="2.1.7" />
 				<dependency id="BitMiracle.LibTiff.NET" version="2.4.649" />

--- a/NuGet/IronSoftware.Drawing.nuspec
+++ b/NuGet/IronSoftware.Drawing.nuspec
@@ -40,21 +40,21 @@ Supports:
 
 For general support and technical inquiries, please email us at: support@ironsoftware.com</description>
 		<summary>IronSoftware.System.Drawing is an open-source solution for .NET developers to replace System.Drawing.Common with a universal and flexible library.</summary>
-		<releaseNotes>- Updates IronSoftware.Drawing.Abstractions to 2026.1.1.
+		<releaseNotes>- Updates IronSoftware.Drawing.Abstractions to 2026.1.2.
 - Updates SixLabors.ImageSharp to 2.1.13 (netstandard2.0) and 3.1.12 (net6.0).</releaseNotes>
 		<copyright>Copyright © Iron Software 2022-2026</copyright>
 		<tags>Images, Bitmap, SkiaSharp, SixLabors, BitMiracle, Maui, SVG, TIFF, TIF, GIF, JPEG, PNG, Color, Rectangle, Drawing, C#, VB.NET, ASPX, create, render, generate, standard, netstandard2.0, core, netcore</tags>
 		<repository type="git" url="https://github.com/iron-software/IronSoftware.Drawing.Common" commit="$commit$" />
 		<dependencies>
 			<group targetFramework="netstandard2.0">
-				<dependency id="IronSoftware.Drawing.Abstractions" version="2026.1.1" />
+				<dependency id="IronSoftware.Drawing.Abstractions" version="2026.1.2" />
 				<dependency id="SixLabors.ImageSharp" version="2.1.13" />
 				<dependency id="SixLabors.ImageSharp.Drawing" version="1.0.0" />
 				<dependency id="BitMiracle.LibTiff.NET" version="2.4.649" />
 				<dependency id="System.Memory" version="4.5.5" />
 			</group>
 			<group targetFramework="net60">
-				<dependency id="IronSoftware.Drawing.Abstractions" version="2026.1.1" />
+				<dependency id="IronSoftware.Drawing.Abstractions" version="2026.1.2" />
 				<dependency id="SixLabors.ImageSharp" version="3.1.12" />
 				<dependency id="SixLabors.ImageSharp.Drawing" version="2.1.7" />
 				<dependency id="BitMiracle.LibTiff.NET" version="2.4.649" />

--- a/NuGet/IronSoftware.Drawing.nuspec
+++ b/NuGet/IronSoftware.Drawing.nuspec
@@ -48,14 +48,14 @@ For general support and technical inquiries, please email us at: support@ironsof
 		<repository type="git" url="https://github.com/iron-software/IronSoftware.Drawing.Common" commit="$commit$" />
 		<dependencies>
 			<group targetFramework="netstandard2.0">
-				<dependency id="IronSoftware.Drawing.Abstractions" version="2026.1.40077-ci" />
+				<dependency id="IronSoftware.Drawing.Abstractions" version="2026.2.40142-ci" />
 				<dependency id="SixLabors.ImageSharp" version="2.1.11" />
 				<dependency id="SixLabors.ImageSharp.Drawing" version="1.0.0" />
 				<dependency id="BitMiracle.LibTiff.NET" version="2.4.649" />
 				<dependency id="System.Memory" version="4.5.5" />
 			</group>
 			<group targetFramework="net60">
-				<dependency id="IronSoftware.Drawing.Abstractions" version="2026.1.40077-ci" />
+				<dependency id="IronSoftware.Drawing.Abstractions" version="2026.2.40142-ci" />
 				<dependency id="SixLabors.ImageSharp" version="3.1.11" />
 				<dependency id="SixLabors.ImageSharp.Drawing" version="2.1.7" />
 				<dependency id="BitMiracle.LibTiff.NET" version="2.4.649" />

--- a/NuGet/IronSoftware.Drawing.nuspec
+++ b/NuGet/IronSoftware.Drawing.nuspec
@@ -48,14 +48,14 @@ For general support and technical inquiries, please email us at: support@ironsof
 		<repository type="git" url="https://github.com/iron-software/IronSoftware.Drawing.Common" commit="$commit$" />
 		<dependencies>
 			<group targetFramework="netstandard2.0">
-				<dependency id="IronSoftware.Drawing.Abstractions" version="2025.4.2" />
+				<dependency id="IronSoftware.Drawing.Abstractions" version="2025.9.4-prerelease" />
 				<dependency id="SixLabors.ImageSharp" version="2.1.11" />
 				<dependency id="SixLabors.ImageSharp.Drawing" version="1.0.0" />
 				<dependency id="BitMiracle.LibTiff.NET" version="2.4.649" />
 				<dependency id="System.Memory" version="4.5.5" />
 			</group>
 			<group targetFramework="net60">
-				<dependency id="IronSoftware.Drawing.Abstractions" version="2025.4.2" />
+				<dependency id="IronSoftware.Drawing.Abstractions" version="2025.9.4-prerelease" />
 				<dependency id="SixLabors.ImageSharp" version="3.1.11" />
 				<dependency id="SixLabors.ImageSharp.Drawing" version="2.1.7" />
 				<dependency id="BitMiracle.LibTiff.NET" version="2.4.649" />


### PR DESCRIPTION
## Description

* Update `IronSoftware.Drawing.Abstractions` to 2026.1.1
* Update `SixLabors.ImageSharp` to 2.1.13 (netstandard2.0) and 3.1.12 (net6.0)