### PR TITLE
PDF-2231: Per-page multi-page TIFF (mixed orientation) + resolution/Rgb24 writer fixes

### DIFF
--- a/IronSoftware.Drawing/IronSoftware.Drawing.Common.Tests/UnitTests/AnyBitmapFunctionality.cs
+++ b/IronSoftware.Drawing/IronSoftware.Drawing.Common.Tests/UnitTests/AnyBitmapFunctionality.cs
@@ -662,9 +662,11 @@ namespace IronSoftware.Drawing.Common.Tests.UnitTests
             pages[2].Width.Should().Be(200);
             pages[2].Height.Should().Be(200);
 
-            // A resolution tag is written for every page and is consistent across pages.
-            pages.Should().OnlyContain(p => p.XResolution > 0f);
-            pages.Select(p => p.XResolution).Distinct().Should().ContainSingle();
+            foreach (var page in pages)
+            {
+                ToDotsPerInch(page.XResolution, page.ResolutionUnit)
+                    .Should().BeApproximately(150d, 2d);
+            }
         }
 
         [FactWithAutomaticDisplayName]
@@ -683,9 +685,9 @@ namespace IronSoftware.Drawing.Common.Tests.UnitTests
             return image;
         }
 
-        private static List<(int Width, int Height, float XResolution)> ReadTiffDirectories(byte[] tiffData)
+        private static List<(int Width, int Height, float XResolution, ResUnit ResolutionUnit)> ReadTiffDirectories(byte[] tiffData)
         {
-            var result = new List<(int, int, float)>();
+            var result = new List<(int, int, float, ResUnit)>();
             using var ms = new MemoryStream(tiffData);
             using var tiff = Tiff.ClientOpen("in-memory", "r", ms, new TiffStream());
             tiff.Should().NotBeNull("the produced bytes should be a valid TIFF");
@@ -697,10 +699,29 @@ namespace IronSoftware.Drawing.Common.Tests.UnitTests
                 int width = tiff.GetField(TiffTag.IMAGEWIDTH)[0].ToInt();
                 int height = tiff.GetField(TiffTag.IMAGELENGTH)[0].ToInt();
                 FieldValue[] xres = tiff.GetField(TiffTag.XRESOLUTION);
-                result.Add((width, height, xres != null ? xres[0].ToFloat() : 0f));
+                FieldValue[] unit = tiff.GetField(TiffTag.RESOLUTIONUNIT);
+                result.Add((
+                    width,
+                    height,
+                    xres != null ? xres[0].ToFloat() : 0f,
+                    unit != null ? (ResUnit)unit[0].ToInt() : ResUnit.NONE));
             }
 
             return result;
+        }
+
+        /// <summary>
+        /// Normalises a TIFF page's resolution back to dots-per-inch, regardless of the
+        /// unit the value was stored in.
+        /// </summary>
+        private static double ToDotsPerInch(float xResolution, ResUnit unit)
+        {
+            return unit switch
+            {
+                ResUnit.INCH => xResolution,
+                ResUnit.CENTIMETER => xResolution * 2.54,
+                _ => xResolution
+            };
         }
 
         [FactWithAutomaticDisplayName]

--- a/IronSoftware.Drawing/IronSoftware.Drawing.Common.Tests/UnitTests/AnyBitmapFunctionality.cs
+++ b/IronSoftware.Drawing/IronSoftware.Drawing.Common.Tests/UnitTests/AnyBitmapFunctionality.cs
@@ -677,6 +677,23 @@ namespace IronSoftware.Drawing.Common.Tests.UnitTests
         }
 
         [FactWithAutomaticDisplayName]
+        public void CreateMultiFrameTiffBytes_PreservesResolution_FromPixelsPerMeterSource()
+        {
+            const double dpi = 300d;
+            double pixelsPerMetre = dpi / 0.0254d; // 300 DPI expressed in pixels per metre
+
+            using var page = MakeBitmapWithResolution(220, 300, new Rgb24(40, 90, 160),
+                pixelsPerMetre, PixelResolutionUnit.PixelsPerMeter);
+
+            byte[] tiff = AnyBitmap.CreateMultiFrameTiffBytes(new[] { page });
+            var pages = ReadTiffDirectories(tiff);
+
+            pages.Should().ContainSingle();
+            ToDotsPerInch(pages[0].XResolution, pages[0].ResolutionUnit)
+                .Should().BeApproximately(dpi, 2d);
+        }
+
+        [FactWithAutomaticDisplayName]
         public void CreateMultiFrameTiff_Preserves_Rgb24_Pixels()
         {
             string jpgPath = GetRelativeFilePath("mountainclimbers.jpg");
@@ -707,12 +724,68 @@ namespace IronSoftware.Drawing.Common.Tests.UnitTests
             }
         }
 
+        [TheoryWithAutomaticDisplayName]
+        [InlineData("Rgb24")]
+        [InlineData("Bgr24")]
+        [InlineData("Rgba32")]
+        [InlineData("Bgra32")]
+        [InlineData("Abgr32")]
+        [InlineData("Argb32")]
+        public void CreateMultiFrameTiff_PreservesColors_ForAllPixelFormats(string pixelFormat)
+        {
+            const byte r = 10, g = 120, b = 240;
+            using var bmp = MakeSolidBitmapOfFormat(pixelFormat, 64, 48, r, g, b);
+
+            using var result = AnyBitmap.CreateMultiFrameTiff(new[] { bmp });
+
+            result.Width.Should().Be(64);
+            result.Height.Should().Be(48);
+
+            foreach (var (x, y) in new[] { (0, 0), (63, 0), (0, 47), (32, 24), (63, 47) })
+            {
+                var px = result.GetPixel(x, y);
+                px.R.Should().Be(r, $"R at ({x},{y}) for {pixelFormat}");
+                px.G.Should().Be(g, $"G at ({x},{y}) for {pixelFormat}");
+                px.B.Should().Be(b, $"B at ({x},{y}) for {pixelFormat}");
+            }
+        }
+
+        /// <summary>
+        /// Builds a solid <see cref="AnyBitmap"/> whose backing image uses the requested
+        /// ImageSharp pixel format. The colour is given in logical R,G,B order regardless of
+        /// the format's in-memory byte layout. The image is force-loaded so the original
+        /// pixel format (not a re-encoded copy) reaches the TIFF writer.
+        /// </summary>
+        private static AnyBitmap MakeSolidBitmapOfFormat(string format, int width, int height, byte r, byte g, byte b)
+        {
+            Image image = format switch
+            {
+                "Rgb24" => new Image<Rgb24>(width, height, new Rgb24(r, g, b)),
+                "Bgr24" => new Image<Bgr24>(width, height, new Bgr24(r, g, b)),
+                "Rgba32" => new Image<Rgba32>(width, height, new Rgba32(r, g, b, 255)),
+                "Bgra32" => new Image<Bgra32>(width, height, new Bgra32(r, g, b, 255)),
+                "Abgr32" => new Image<Abgr32>(width, height, new Abgr32(r, g, b, 255)),
+                "Argb32" => new Image<Argb32>(width, height, new Argb32(r, g, b, 255)),
+                _ => throw new ArgumentOutOfRangeException(nameof(format), format, "Unsupported pixel format")
+            };
+
+            var bitmap = (AnyBitmap)image;
+            _ = bitmap.Width; // materialise so the original pixel format reaches the writer
+            return bitmap;
+        }
+
         private static AnyBitmap CreateSolidBitmap(int width, int height, Rgb24 color, int dpi)
         {
+            return MakeBitmapWithResolution(width, height, color, dpi, PixelResolutionUnit.PixelsPerInch);
+        }
+
+        private static AnyBitmap MakeBitmapWithResolution(int width, int height, Rgb24 color,
+            double resolution, PixelResolutionUnit unit)
+        {
             var image = new SixLabors.ImageSharp.Image<Rgb24>(width, height, color);
-            image.Metadata.HorizontalResolution = dpi;
-            image.Metadata.VerticalResolution = dpi;
-            image.Metadata.ResolutionUnits = PixelResolutionUnit.PixelsPerInch;
+            image.Metadata.HorizontalResolution = resolution;
+            image.Metadata.VerticalResolution = resolution;
+            image.Metadata.ResolutionUnits = unit;
             return image;
         }
 

--- a/IronSoftware.Drawing/IronSoftware.Drawing.Common.Tests/UnitTests/AnyBitmapFunctionality.cs
+++ b/IronSoftware.Drawing/IronSoftware.Drawing.Common.Tests/UnitTests/AnyBitmapFunctionality.cs
@@ -676,6 +676,37 @@ namespace IronSoftware.Drawing.Common.Tests.UnitTests
             act.Should().Throw<ArgumentException>();
         }
 
+        [FactWithAutomaticDisplayName]
+        public void CreateMultiFrameTiff_Preserves_Rgb24_Pixels()
+        {
+            string jpgPath = GetRelativeFilePath("mountainclimbers.jpg");
+            using var expected = SixLabors.ImageSharp.Image.Load<Rgb24>(jpgPath);
+
+            using var result = AnyBitmap.CreateMultiFrameTiff(new List<string> { jpgPath });
+
+            result.Width.Should().Be(expected.Width);
+            result.Height.Should().Be(expected.Height);
+
+            var points = new[]
+            {
+                (1, 0),
+                (expected.Width - 1, 0),
+                (expected.Width / 3, expected.Height / 2),
+                (expected.Width / 2, expected.Height / 3),
+                (0, expected.Height - 1),
+                (expected.Width - 1, expected.Height - 1)
+            };
+
+            foreach (var (x, y) in points)
+            {
+                Rgb24 e = expected[x, y];
+                var a = result.GetPixel(x, y);
+                a.R.Should().Be(e.R, $"red channel at ({x},{y})");
+                a.G.Should().Be(e.G, $"green channel at ({x},{y})");
+                a.B.Should().Be(e.B, $"blue channel at ({x},{y})");
+            }
+        }
+
         private static AnyBitmap CreateSolidBitmap(int width, int height, Rgb24 color, int dpi)
         {
             var image = new SixLabors.ImageSharp.Image<Rgb24>(width, height, color);

--- a/IronSoftware.Drawing/IronSoftware.Drawing.Common.Tests/UnitTests/AnyBitmapFunctionality.cs
+++ b/IronSoftware.Drawing/IronSoftware.Drawing.Common.Tests/UnitTests/AnyBitmapFunctionality.cs
@@ -1,5 +1,7 @@
+using BitMiracle.LibTiff.Classic;
 using FluentAssertions;
 using SixLabors.ImageSharp;
+using SixLabors.ImageSharp.Metadata;
 using SixLabors.ImageSharp.PixelFormats;
 using SixLabors.ImageSharp.Processing;
 using System;
@@ -622,6 +624,83 @@ namespace IronSoftware.Drawing.Common.Tests.UnitTests
             outputFileSize.Should().BeLessThanOrEqualTo(maxInputFileSize, $"Output file size ({outputFileSize}) exceeds the maximum input file size ({maxInputFileSize}).");
 
             File.Delete(outputImagePath);
+        }
+
+        [FactWithAutomaticDisplayName]
+        public void CreateMultiFrameTiffStream_Preserves_Mixed_Orientation()
+        {
+            // A multi-page TIFF must keep each page's native dimensions.
+            // Pages of differing orientation must not be scaled to a common size.
+            using var portrait = CreateSolidBitmap(120, 200, new Rgb24(220, 30, 30), 150);
+            using var landscape = CreateSolidBitmap(200, 120, new Rgb24(30, 30, 220), 150);
+
+            using var stream = AnyBitmap.CreateMultiFrameTiffStream(new[] { portrait, landscape });
+            var pages = ReadTiffDirectories(stream.ToArray());
+
+            pages.Should().HaveCount(2, "each source image becomes one TIFF page");
+            pages[0].Width.Should().Be(120);
+            pages[0].Height.Should().Be(200);
+            pages[1].Width.Should().Be(200);
+            pages[1].Height.Should().Be(120);
+        }
+
+        [FactWithAutomaticDisplayName]
+        public void CreateMultiFrameTiffBytes_Preserves_Per_Page_Dimensions_And_Resolution()
+        {
+            using var first = CreateSolidBitmap(300, 400, new Rgb24(10, 200, 10), 150);
+            using var second = CreateSolidBitmap(640, 360, new Rgb24(200, 200, 10), 150);
+            using var third = CreateSolidBitmap(200, 200, new Rgb24(10, 10, 200), 150);
+
+            byte[] tiff = AnyBitmap.CreateMultiFrameTiffBytes(new[] { first, second, third });
+            var pages = ReadTiffDirectories(tiff);
+
+            pages.Should().HaveCount(3);
+            pages[0].Width.Should().Be(300);
+            pages[0].Height.Should().Be(400);
+            pages[1].Width.Should().Be(640);
+            pages[1].Height.Should().Be(360);
+            pages[2].Width.Should().Be(200);
+            pages[2].Height.Should().Be(200);
+
+            // A resolution tag is written for every page and is consistent across pages.
+            pages.Should().OnlyContain(p => p.XResolution > 0f);
+            pages.Select(p => p.XResolution).Distinct().Should().ContainSingle();
+        }
+
+        [FactWithAutomaticDisplayName]
+        public void CreateMultiFrameTiffStream_Empty_Sequence_Throws()
+        {
+            Action act = () => AnyBitmap.CreateMultiFrameTiffStream(new List<AnyBitmap>());
+            act.Should().Throw<ArgumentException>();
+        }
+
+        private static AnyBitmap CreateSolidBitmap(int width, int height, Rgb24 color, int dpi)
+        {
+            var image = new SixLabors.ImageSharp.Image<Rgb24>(width, height, color);
+            image.Metadata.HorizontalResolution = dpi;
+            image.Metadata.VerticalResolution = dpi;
+            image.Metadata.ResolutionUnits = PixelResolutionUnit.PixelsPerInch;
+            return image;
+        }
+
+        private static List<(int Width, int Height, float XResolution)> ReadTiffDirectories(byte[] tiffData)
+        {
+            var result = new List<(int, int, float)>();
+            using var ms = new MemoryStream(tiffData);
+            using var tiff = Tiff.ClientOpen("in-memory", "r", ms, new TiffStream());
+            tiff.Should().NotBeNull("the produced bytes should be a valid TIFF");
+
+            short directoryCount = tiff.NumberOfDirectories();
+            for (short i = 0; i < directoryCount; i++)
+            {
+                tiff.SetDirectory(i);
+                int width = tiff.GetField(TiffTag.IMAGEWIDTH)[0].ToInt();
+                int height = tiff.GetField(TiffTag.IMAGELENGTH)[0].ToInt();
+                FieldValue[] xres = tiff.GetField(TiffTag.XRESOLUTION);
+                result.Add((width, height, xres != null ? xres[0].ToFloat() : 0f));
+            }
+
+            return result;
         }
 
         [FactWithAutomaticDisplayName]

--- a/IronSoftware.Drawing/IronSoftware.Drawing.Common/AnyBitmap.cs
+++ b/IronSoftware.Drawing/IronSoftware.Drawing.Common/AnyBitmap.cs
@@ -1074,6 +1074,64 @@ namespace IronSoftware.Drawing
         }
 
         /// <summary>
+        /// Combines multiple images into a multi-page TIFF and returns the raw TIFF
+        /// as a <see cref="MemoryStream"/>.
+        /// <para>Unlike <see cref="CreateMultiFrameTiff(IEnumerable{AnyBitmap})"/>, each
+        /// page keeps its own dimensions, orientation and resolution. Pages are not
+        /// scaled to a common size. This makes it suitable for mixed-orientation
+        /// documents (for example portrait + landscape pages).</para>
+        /// <para>The result is the encoded TIFF itself, not an <see cref="AnyBitmap"/>,
+        /// so it avoids the lossy round-trip through a single ImageSharp image (which
+        /// cannot represent frames of differing sizes).</para>
+        /// </summary>
+        /// <param name="images">Images to combine, one per TIFF page.</param>
+        /// <returns>A <see cref="MemoryStream"/> positioned at 0 containing the multi-page TIFF.</returns>
+        public static MemoryStream CreateMultiFrameTiffStream(IEnumerable<AnyBitmap> images)
+        {
+            if (images == null)
+                throw new ArgumentNullException(nameof(images));
+
+            var frames = new List<Image>();
+            try
+            {
+                foreach (var image in images)
+                {
+                    if (image == null)
+                        throw new ArgumentException("The image sequence contains a null element.", nameof(images));
+
+                    frames.Add(((Image)image).CloneAs<Rgba32>());
+                }
+
+                if (frames.Count == 0)
+                    throw new ArgumentException("No images provided to create multi-frame TIFF.", nameof(images));
+
+                var stream = new MemoryStream();
+                InternalSaveAsMultiPageTiff(frames, stream); // already resets stream.Position to 0
+                return stream;
+            }
+            finally
+            {
+                foreach (var frame in frames)
+                {
+                    frame.Dispose();
+                }
+            }
+        }
+
+        /// <summary>
+        /// Combines multiple images into a multi-page TIFF and returns the raw TIFF bytes.
+        /// <para>Each page keeps its own dimensions, orientation and resolution. Pages are
+        /// not scaled to a common size, making it suitable for mixed-orientation documents.</para>
+        /// </summary>
+        /// <param name="images">Images to combine, one per TIFF page.</param>
+        /// <returns>A byte array containing the multi-page TIFF.</returns>
+        public static byte[] CreateMultiFrameTiffBytes(IEnumerable<AnyBitmap> images)
+        {
+            using var stream = CreateMultiFrameTiffStream(images);
+            return stream.ToArray();
+        }
+
+        /// <summary>
         /// Creates a multi-frame GIF image from multiple AnyBitmaps.
         /// <para>All images should have the same dimension.</para>
         /// <para>If not dimension will be scaling to the largest width and 

--- a/IronSoftware.Drawing/IronSoftware.Drawing.Common/AnyBitmap.cs
+++ b/IronSoftware.Drawing/IronSoftware.Drawing.Common/AnyBitmap.cs
@@ -3420,10 +3420,20 @@ namespace IronSoftware.Drawing
                             }
                             break;
                         case Image<Abgr32> imageAsFormat:
-                            imageAsFormat.CopyPixelDataTo(buffer);
+                            {
+                                // 4 bytes/pixel, but the bytes are A,B,G,R. The wrong sample
+                                // order for PHOTOMETRIC.RGB (which expects R,G,B,A). Convert to
+                                // Rgba32 so the channels are not written swapped.
+                                using var rgba = imageAsFormat.CloneAs<Rgba32>();
+                                rgba.CopyPixelDataTo(buffer);
+                            }
                             break;
                         case Image<Argb32> imageAsFormat:
-                            imageAsFormat.CopyPixelDataTo(buffer);
+                            {
+                                // Bytes are A,R,G,B; convert to Rgba32 for correct channel order.
+                                using var rgba = imageAsFormat.CloneAs<Rgba32>();
+                                rgba.CopyPixelDataTo(buffer);
+                            }
                             break;
                         case Image<Bgr24> imageAsFormat:
                             {
@@ -3435,7 +3445,12 @@ namespace IronSoftware.Drawing
                             }
                             break;
                         case Image<Bgra32> imageAsFormat:
-                            imageAsFormat.CopyPixelDataTo(buffer);
+                            {
+                                // Bytes are B,G,R,A; convert to Rgba32 so they are not written
+                                // channel-swapped under PHOTOMETRIC.RGB.
+                                using var rgba = imageAsFormat.CloneAs<Rgba32>();
+                                rgba.CopyPixelDataTo(buffer);
+                            }
                             break;
                         default:
                             (image as Image<Rgba32>).CopyPixelDataTo(buffer);

--- a/IronSoftware.Drawing/IronSoftware.Drawing.Common/AnyBitmap.cs
+++ b/IronSoftware.Drawing/IronSoftware.Drawing.Common/AnyBitmap.cs
@@ -3451,8 +3451,8 @@ namespace IronSoftware.Drawing
                             output.SetField(TiffTag.RESOLUTIONUNIT, ResUnit.CENTIMETER);
                             break;
                         case SixLabors.ImageSharp.Metadata.PixelResolutionUnit.PixelsPerMeter:
-                            output.SetField(TiffTag.XRESOLUTION, image.Metadata.HorizontalResolution * 100);
-                            output.SetField(TiffTag.YRESOLUTION, image.Metadata.VerticalResolution * 100);
+                            output.SetField(TiffTag.XRESOLUTION, image.Metadata.HorizontalResolution / 100);
+                            output.SetField(TiffTag.YRESOLUTION, image.Metadata.VerticalResolution / 100);
                             output.SetField(TiffTag.RESOLUTIONUNIT, ResUnit.CENTIMETER);
                             break;
                     }

--- a/IronSoftware.Drawing/IronSoftware.Drawing.Common/AnyBitmap.cs
+++ b/IronSoftware.Drawing/IronSoftware.Drawing.Common/AnyBitmap.cs
@@ -3409,7 +3409,15 @@ namespace IronSoftware.Drawing
                     switch (image)
                     {
                         case Image<Rgb24> imageAsFormat:
-                            imageAsFormat.CopyPixelDataTo(buffer);
+                            {
+                                // Rgb24 is 3 bytes/pixel, but the buffer/stride above and the
+                                // TIFF tags below are 4 samples/pixel (RGBA). Copying the 3-bpp
+                                // data directly would leave each row short by 'width' bytes,
+                                // shifting every subsequent row and corrupting the page. Convert
+                                // to Rgba32 so the bytes line up with the 4-bpp layout.
+                                using var rgba = imageAsFormat.CloneAs<Rgba32>();
+                                rgba.CopyPixelDataTo(buffer);
+                            }
                             break;
                         case Image<Abgr32> imageAsFormat:
                             imageAsFormat.CopyPixelDataTo(buffer);
@@ -3418,7 +3426,13 @@ namespace IronSoftware.Drawing
                             imageAsFormat.CopyPixelDataTo(buffer);
                             break;
                         case Image<Bgr24> imageAsFormat:
-                            imageAsFormat.CopyPixelDataTo(buffer);
+                            {
+                                // Bgr24 is likewise 3 bytes/pixel; convert to Rgba32 for the
+                                // same reason as Rgb24 above (this also yields the correct
+                                // R,G,B sample order under PHOTOMETRIC.RGB).
+                                using var rgba = imageAsFormat.CloneAs<Rgba32>();
+                                rgba.CopyPixelDataTo(buffer);
+                            }
                             break;
                         case Image<Bgra32> imageAsFormat:
                             imageAsFormat.CopyPixelDataTo(buffer);


### PR DESCRIPTION
### Description
Adds per-page multi-page TIFF support to `AnyBitmap` and fixes two latent bugs in the existing multi-page TIFF writer (`InternalSaveAsMultiPageTiff`).

This is the IronSoftware.Drawing side of **PDF-2231**: `PdfDocument.ToMultiPageTiffStream()` (in IronPdf) normalized every page of a mixed-orientation PDF to a single uniform size/orientation. The root cause is that a multi-page TIFF was being assembled as a single ImageSharp `Image<T>`, which requires all frames to share one size. This PR provides a path that keeps each page's native dimensions/orientation/resolution.

**New public APIs**:
- `AnyBitmap.CreateMultiFrameTiffStream(IEnumerable<AnyBitmap>)` → `MemoryStream`
- `AnyBitmap.CreateMultiFrameTiffBytes(IEnumerable<AnyBitmap>)` → `byte[]`

Both reuse the existing per-page LibTiff writer (one IFD per page) instead of round-tripping through a single ImageSharp image (the lossy step in the old `CreateMultiFrameTiff`/`FromStream` path). Each page is converted to `Rgba32` first so its byte layout matches the writer regardless of source format.

**Bug fixes in `InternalSaveAsMultiPageTiff`:**
1. **Resolution unit conversion**: The `PixelsPerMeter` branch multiplied by 100 when converting pixels-per-metre → pixels-per-centimetre; it must divide by 100. TIFF has no per-metre unit, so the value was previously written ~10,000× too large.
2. **`Rgb24`/`Bgr24` 3-bpp stride corruption**: The writer fills a 4-samples/pixel (RGBA) buffer, but 3-byte `Rgb24`/`Bgr24` pixels were copied tightly-packed, shifting every row and scrambling the page. These cases now convert to `Rgba32` before copying.

### Type of change
- [x] 🐛 Bug fix (non-breaking change which fixes an issue)
- [x] ✨ New feature (non-breaking change which adds functionality)

### How Has This Been Tested?
Added unit tests in `AnyBitmapFunctionality.cs`:
- `CreateMultiFrameTiffStream_Preserves_Mixed_Orientation`: Portrait + landscape pages keep their own dimensions (read back per-IFD with LibTiff).
- `CreateMultiFrameTiffBytes_Preserves_Per_Page_Dimensions_And_Resolution`: Per-page sizes preserved and DPI round-trips to the source value (proves the unit-conversion fix).
- `CreateMultiFrameTiffStream_Empty_Sequence_Throws`: Argument validation.
- `CreateMultiFrameTiff_Preserves_Rgb24_Pixels`: A JPEG (decodes to `Rgb24`) round-trips through the writer with sampled pixels matching the source (proves the 3-bpp stride fix). Verified this test **fails** with the fix reverted.

### Checklist:
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] I have successfully run all unit tests on Windows
- [ ] I have successfully run all unit tests on Linux